### PR TITLE
refactor(Popover): change popover default slot to content

### DIFF
--- a/docs/components/content/examples/vue/popover/ExampleVuePopoverBasic.vue
+++ b/docs/components/content/examples/vue/popover/ExampleVuePopoverBasic.vue
@@ -1,70 +1,70 @@
 <template>
   <div class="grid h-50 place-items-center">
     <NPopover :_popover-content="{ align: 'start', class: 'w-80' }">
-      <NButton btn="solid-white">
-        Open popover
-      </NButton>
-      <template #content>
-        <div class="grid gap-4">
-          <div class="space-y-2">
-            <h4 class="font-medium leading-none">
-              Dimensions
-            </h4>
-            <p class="text-sm text-muted">
-              Set the dimensions for the layer.
-            </p>
+      <template #trigger>
+        <NButton btn="solid-white">
+          Open popover
+        </NButton>
+      </template>
+      <div class="grid gap-4">
+        <div class="space-y-2">
+          <h4 class="font-medium leading-none">
+            Dimensions
+          </h4>
+          <p class="text-sm text-muted">
+            Set the dimensions for the layer.
+          </p>
+        </div>
+        <div class="grid gap-2">
+          <div class="grid grid-cols-3 items-center gap-4">
+            <NLabel for="width">
+              Width
+            </NLabel>
+            <NInput
+              id="width"
+              model-value="100%"
+              :una="{
+                inputWrapper: 'col-span-2',
+              }"
+            />
           </div>
-          <div class="grid gap-2">
-            <div class="grid grid-cols-3 items-center gap-4">
-              <NLabel for="width">
-                Width
-              </NLabel>
-              <NInput
-                id="width"
-                model-value="100%"
-                :una="{
-                  inputWrapper: 'col-span-2',
-                }"
-              />
-            </div>
-            <div class="grid grid-cols-3 items-center gap-4">
-              <NLabel for="maxWidth">
-                Max. width
-              </NLabel>
-              <NInput
-                id="maxWidth"
-                model-value="300px"
-                :una="{
-                  inputWrapper: 'col-span-2',
-                }"
-              />
-            </div>
-            <div class="grid grid-cols-3 items-center gap-4">
-              <NLabel for="height">
-                Height
-              </NLabel>
-              <NInput
-                id="height"
-                type="text"
-                :una="{
-                  inputWrapper: 'col-span-2',
-                }"
-              />
-            </div>
-            <div class="grid grid-cols-3 items-center gap-4">
-              <NLabel for="maxHeight">
-                Max. height
-              </NLabel>
-              <NInput
-                id="maxHeight"
-                :una="{
-                  inputWrapper: 'col-span-2',
-                }"
-              />
-            </div>
+          <div class="grid grid-cols-3 items-center gap-4">
+            <NLabel for="maxWidth">
+              Max. width
+            </NLabel>
+            <NInput
+              id="maxWidth"
+              model-value="300px"
+              :una="{
+                inputWrapper: 'col-span-2',
+              }"
+            />
+          </div>
+          <div class="grid grid-cols-3 items-center gap-4">
+            <NLabel for="height">
+              Height
+            </NLabel>
+            <NInput
+              id="height"
+              type="text"
+              :una="{
+                inputWrapper: 'col-span-2',
+              }"
+            />
+          </div>
+          <div class="grid grid-cols-3 items-center gap-4">
+            <NLabel for="maxHeight">
+              Max. height
+            </NLabel>
+            <NInput
+              id="maxHeight"
+              :una="{
+                inputWrapper: 'col-span-2',
+              }"
+            />
           </div>
         </div>
-      </template>
+      </div>
     </NPopover>
   </div>
 </template>

--- a/docs/content/3.components/popover.md
+++ b/docs/content/3.components/popover.md
@@ -35,8 +35,8 @@ Displays rich content in a portal, triggered by a button.
 
 | Name           | Description                  | Props  |
 | -------------- | ---------------------------- | ------ |
-| `default`      | The button trigger.          | `open` |
-| `content`      | The popover content.         | -      |
+| `trigger`      | The button trigger.          | `open` |
+| `default`      | The popover content.         | -      |
 
 ## Props
 @@@ ../packages/nuxt/src/runtime/types/popover.ts

--- a/packages/nuxt/playground/components/Popover.vue
+++ b/packages/nuxt/playground/components/Popover.vue
@@ -3,69 +3,69 @@
 
 <template>
   <NPopover :_popover-content="{ class: 'w-80', align: 'start', side: 'right' }">
-    <NButton btn="solid-white">
-      Open popover
-    </NButton>
-    <template #content>
-      <div class="grid gap-4">
-        <div class="space-y-2">
-          <h4 class="font-medium leading-none">
-            Dimensions
-          </h4>
-          <p class="text-sm text-muted">
-            Set the dimensions for the layer.
-          </p>
+    <template #trigger>
+      <NButton btn="solid-white">
+        Open popover
+      </NButton>
+    </template>
+    <div class="grid gap-4">
+      <div class="space-y-2">
+        <h4 class="font-medium leading-none">
+          Dimensions
+        </h4>
+        <p class="text-sm text-muted">
+          Set the dimensions for the layer.
+        </p>
+      </div>
+      <div class="grid gap-2">
+        <div class="grid grid-cols-3 items-center gap-4">
+          <NLabel for="width">
+            Width
+          </NLabel>
+          <NInput
+            id="width"
+            model-value="100%"
+            :una="{
+              inputWrapper: 'col-span-2',
+            }"
+          />
         </div>
-        <div class="grid gap-2">
-          <div class="grid grid-cols-3 items-center gap-4">
-            <NLabel for="width">
-              Width
-            </NLabel>
-            <NInput
-              id="width"
-              model-value="100%"
-              :una="{
-                inputWrapper: 'col-span-2',
-              }"
-            />
-          </div>
-          <div class="grid grid-cols-3 items-center gap-4">
-            <NLabel for="maxWidth">
-              Max. width
-            </NLabel>
-            <NInput
-              id="maxWidth"
-              model-value="300px"
-              :una="{
-                inputWrapper: 'col-span-2',
-              }"
-            />
-          </div>
-          <div class="grid grid-cols-3 items-center gap-4">
-            <NLabel for="height">
-              Height
-            </NLabel>
-            <NInput
-              id="height"
-              type="text"
-              :una="{
-                inputWrapper: 'col-span-2',
-              }"
-            />
-          </div>
-          <div class="grid grid-cols-3 items-center gap-4">
-            <NLabel for="maxHeight">
-              Max. height
-            </NLabel>
-            <NInput
-              id="maxHeight"
-              :una="{
-                inputWrapper: 'col-span-2',
-              }"
-            />
-          </div>
+        <div class="grid grid-cols-3 items-center gap-4">
+          <NLabel for="maxWidth">
+            Max. width
+          </NLabel>
+          <NInput
+            id="maxWidth"
+            model-value="300px"
+            :una="{
+              inputWrapper: 'col-span-2',
+            }"
+          />
+        </div>
+        <div class="grid grid-cols-3 items-center gap-4">
+          <NLabel for="height">
+            Height
+          </NLabel>
+          <NInput
+            id="height"
+            type="text"
+            :una="{
+              inputWrapper: 'col-span-2',
+            }"
+          />
+        </div>
+        <div class="grid grid-cols-3 items-center gap-4">
+          <NLabel for="maxHeight">
+            Max. height
+          </NLabel>
+          <NInput
+            id="maxHeight"
+            :una="{
+              inputWrapper: 'col-span-2',
+            }"
+          />
         </div>
       </div>
-    </template>
+    </div>
   </NPopover>
 </template>

--- a/packages/nuxt/src/runtime/components/elements/popover/Popover.vue
+++ b/packages/nuxt/src/runtime/components/elements/popover/Popover.vue
@@ -20,10 +20,10 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 <template>
   <PopoverRoot v-slot="{ open }" v-bind="forwarded">
     <PopoverTrigger as-child>
-      <slot name="default" :open />
+      <slot name="trigger" :open />
     </PopoverTrigger>
     <NPopoverContent v-bind="_popoverContent">
-      <slot name="content" />
+      <slot />
     </NPopoverContent>
   </PopoverRoot>
 </template>

--- a/packages/nuxt/src/runtime/components/misc/ThemeSwitcher.vue
+++ b/packages/nuxt/src/runtime/components/misc/ThemeSwitcher.vue
@@ -51,140 +51,140 @@ function shuffleTheme(): void {
 
 <template>
   <Popover :_popover-content="{ align: 'end', class: 'z-100 w-73 bg-muted' }">
-    <Button
-      btn="soft square"
-      icon
-      label="i-lucide-paintbrush"
-    />
-    <template #content>
-      <div class="flex flex-col">
-        <div class="grid space-y-1">
-          <h1 class="text-md text-base font-semibold">
-            Customize
-          </h1>
-          <p class="text-xs text-muted">
-            Pick a style and color for your components.
-          </p>
-        </div>
+    <template #trigger>
+      <Button
+        btn="soft square"
+        icon
+        label="i-lucide-paintbrush"
+      />
+    </template>
+    <div class="flex flex-col">
+      <div class="grid space-y-1">
+        <h1 class="text-md text-base font-semibold">
+          Customize
+        </h1>
+        <p class="text-xs text-muted">
+          Pick a style and color for your components.
+        </p>
+      </div>
 
-        <Separator />
+      <Separator />
 
-        <div class="space-y-3">
-          <Label for="color" class="text-xs"> Primary Color</Label>
-          <div class="grid grid-cols-7 gap-3">
-            <button
-              v-for="[key, theme] in primaryThemes"
-              :key="key"
-              :style="{ background: theme['--una-primary-hex'] }"
-              class="h-6.5 w-6.5 rounded-full transition-all"
-              :class="[currentPrimaryThemeName === key ? 'ring-2' : 'scale-93']"
-              ring="primary offset-4 offset-base"
-              aria-label="Primary Color"
-              @click="updatePrimaryTheme(key)"
-            />
-          </div>
-        </div>
-
-        <Separator />
-
-        <div class="space-y-3">
-          <Label for="color" class="text-xs"> Gray Color </Label>
-          <div class="grid grid-cols-7 gap-3">
-            <button
-              v-for="[key, theme] in grayThemes"
-              :key="key"
-              :style="{ background: theme['--una-gray-hex'] }"
-              :class="currentGrayThemeName === key ? 'ring-2' : 'scale-93'"
-              class="h-6.5 w-6.5 rounded-full transition-all"
-              aria-label="Gray Color"
-              ring="gray offset-4 offset-base"
-              @click="updateGrayTheme(key)"
-            />
-          </div>
-        </div>
-
-        <Separator />
-
-        <div class="space-y-3">
-          <Label for="radius" class="text-xs"> Radius </Label>
-          <div class="grid grid-cols-5 gap-2 py-1.5">
-            <Button
-              v-for="r in RADIUS"
-              :key="r"
-              btn="solid-gray"
-              size="xs"
-              :class="
-                r === settings.radius
-                  ? 'ring-2 ring-primary'
-                  : ''
-              "
-              @click="settings.radius = r"
-            >
-              {{ r }}
-            </Button>
-          </div>
-        </div>
-
-        <Separator />
-
-        <div class="space-y-3">
-          <Label for="theme" class="text-xs">Mode</Label>
-
-          <div class="flex justify-around py-1.5 space-x-2">
-            <Button
-              btn="solid-gray block"
-              :class="{ 'ring-2 ring-primary': colorMode.preference === 'system' }"
-              leading="i-radix-icons-desktop"
-              class="px-3"
-              size="xs"
-              label="System"
-              @click="colorMode.preference = 'system'"
-            />
-
-            <Button
-              btn="solid-gray block"
-              :class="{ 'ring-2 ring-primary': colorMode.preference === 'light' }"
-              leading="i-radix-icons-sun"
-              class="px-3"
-              size="xs"
-              label="Light"
-              @click="colorMode.preference = 'light'"
-            />
-
-            <Button
-              btn="solid-gray block"
-              :class="{ 'ring-2 ring-primary': colorMode.preference === 'dark' }"
-              leading="i-radix-icons-moon"
-              class="px-3"
-              size="xs"
-              label="Dark"
-              @click="colorMode.preference = 'dark'"
-            />
-          </div>
-        </div>
-
-        <Separator />
-
-        <div class="flex space-x-3">
-          <Button
-            btn="solid-gray block"
-            size="xs"
-            label="Reset"
-            leading="i-radix-icons-reload"
-            @click="reset"
-          />
-          <Button
-            btn="solid block"
-            class="transition"
-            label="Shuffle"
-            leading="i-lucide-paintbrush"
-            :una="{
-              btnLeading: value ? 'rotate-6 transform' : '-rotate-6',
-            }"
-            @click="shuffleTheme"
+      <div class="space-y-3">
+        <Label for="color" class="text-xs"> Primary Color</Label>
+        <div class="grid grid-cols-7 gap-3">
+          <button
+            v-for="[key, theme] in primaryThemes"
+            :key="key"
+            :style="{ background: theme['--una-primary-hex'] }"
+            class="h-6.5 w-6.5 rounded-full transition-all"
+            :class="[currentPrimaryThemeName === key ? 'ring-2' : 'scale-93']"
+            ring="primary offset-4 offset-base"
+            aria-label="Primary Color"
+            @click="updatePrimaryTheme(key)"
           />
         </div>
       </div>
-    </template>
+
+      <Separator />
+
+      <div class="space-y-3">
+        <Label for="color" class="text-xs"> Gray Color </Label>
+        <div class="grid grid-cols-7 gap-3">
+          <button
+            v-for="[key, theme] in grayThemes"
+            :key="key"
+            :style="{ background: theme['--una-gray-hex'] }"
+            :class="currentGrayThemeName === key ? 'ring-2' : 'scale-93'"
+            class="h-6.5 w-6.5 rounded-full transition-all"
+            aria-label="Gray Color"
+            ring="gray offset-4 offset-base"
+            @click="updateGrayTheme(key)"
+          />
+        </div>
+      </div>
+
+      <Separator />
+
+      <div class="space-y-3">
+        <Label for="radius" class="text-xs"> Radius </Label>
+        <div class="grid grid-cols-5 gap-2 py-1.5">
+          <Button
+            v-for="r in RADIUS"
+            :key="r"
+            btn="solid-gray"
+            size="xs"
+            :class="
+              r === settings.radius
+                ? 'ring-2 ring-primary'
+                : ''
+            "
+            @click="settings.radius = r"
+          >
+            {{ r }}
+          </Button>
+        </div>
+      </div>
+
+      <Separator />
+
+      <div class="space-y-3">
+        <Label for="theme" class="text-xs">Mode</Label>
+
+        <div class="flex justify-around py-1.5 space-x-2">
+          <Button
+            btn="solid-gray block"
+            :class="{ 'ring-2 ring-primary': colorMode.preference === 'system' }"
+            leading="i-radix-icons-desktop"
+            class="px-3"
+            size="xs"
+            label="System"
+            @click="colorMode.preference = 'system'"
+          />
+
+          <Button
+            btn="solid-gray block"
+            :class="{ 'ring-2 ring-primary': colorMode.preference === 'light' }"
+            leading="i-radix-icons-sun"
+            class="px-3"
+            size="xs"
+            label="Light"
+            @click="colorMode.preference = 'light'"
+          />
+
+          <Button
+            btn="solid-gray block"
+            :class="{ 'ring-2 ring-primary': colorMode.preference === 'dark' }"
+            leading="i-radix-icons-moon"
+            class="px-3"
+            size="xs"
+            label="Dark"
+            @click="colorMode.preference = 'dark'"
+          />
+        </div>
+      </div>
+
+      <Separator />
+
+      <div class="flex space-x-3">
+        <Button
+          btn="solid-gray block"
+          size="xs"
+          label="Reset"
+          leading="i-radix-icons-reload"
+          @click="reset"
+        />
+        <Button
+          btn="solid block"
+          class="transition"
+          label="Shuffle"
+          leading="i-lucide-paintbrush"
+          :una="{
+            btnLeading: value ? 'rotate-6 transform' : '-rotate-6',
+          }"
+          @click="shuffleTheme"
+        />
+      </div>
+    </div>
   </Popover>
 </template>


### PR DESCRIPTION
⚠️ **Breaking Change**

This makes the focus on the popover, not the trigger.

It also simplifies scenarios when using the `open` slot, as you would have to have a separate `<template #default="{slot}">` anyway.