### PR TITLE
fix(types): Generate nuxt types automatically at install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm lint
-      - run: pnpm build
       - run: pnpm typecheck
+      - run: pnpm build
       - name: Release Edge
         if: |
           github.event_name == 'push' &&

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "release": "pnpm test && bumpp -r -x \"pnpm run changelog\" --all && pnpm -r publish && tsx scripts/release.ts",
     "start": "echo 'No start script defined'",
     "test": "vitest",
-    "typecheck": "vue-tsc --noEmit",
+    "typecheck": "pnpm -C packages/nuxt dev:prepare && vue-tsc --noEmit",
     "clear": "rimraf packages/*/{dist,es,lib}",
     "reset": "pnpm store prune && rimraf docs/.nuxt docs/node_modules node_modules pnpm-lock.yaml packages/**/{node_modules} && ni",
     "stub": "pnpm -r --filter=./packages/* run stub",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "release": "pnpm test && bumpp -r -x \"pnpm run changelog\" --all && pnpm -r publish && tsx scripts/release.ts",
     "start": "echo 'No start script defined'",
     "test": "vitest",
-    "typecheck": "pnpm -C packages/nuxt dev:prepare && vue-tsc --noEmit",
+    "typecheck": "vue-tsc --noEmit",
     "clear": "rimraf packages/*/{dist,es,lib}",
     "reset": "pnpm store prune && rimraf docs/.nuxt docs/node_modules node_modules pnpm-lock.yaml packages/**/{node_modules} && ni",
     "stub": "pnpm -r --filter=./packages/* run stub",

--- a/packages/nuxt/build.config.ts
+++ b/packages/nuxt/build.config.ts
@@ -2,7 +2,7 @@ import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
   entries: [
-    'src/una.config',
+    'src/una.config.ts',
   ],
   externals: [
     'nuxt',

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -27,10 +27,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "pnpm dev:prepare && pnpm dev:prepare && nuxt-build-module",
+    "build": "nuxt-build-module",
     "stub": "nuxt-build-module build --stub",
     "dev": "pnpm dev:prepare && nuxi dev playground",
-    "dev:prepare": "pnpm stub && nuxt-module-build prepare && nuxi prepare playground",
+    "prepare": "pnpm stub && nuxt-module-build prepare && nuxi prepare playground",
     "prepack": "nr build",
     "playground:build": "nuxi generate playground",
     "playground:preview": "nuxi preview playground"

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -27,10 +27,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "nuxt-build-module",
+    "build": "pnpm dev:prepare && pnpm dev:prepare && nuxt-build-module",
     "stub": "nuxt-build-module build --stub",
-    "dev": "nuxi dev playground",
-    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
+    "dev": "pnpm dev:prepare && nuxi dev playground",
+    "dev:prepare": "pnpm stub && nuxt-module-build prepare && nuxi prepare playground",
     "prepack": "nr build",
     "playground:build": "nuxi generate playground",
     "playground:preview": "nuxi preview playground"

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -30,6 +30,7 @@
     "build": "nuxt-build-module",
     "stub": "nuxt-build-module build --stub",
     "dev": "nuxi dev playground",
+    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "prepack": "nr build",
     "playground:build": "nuxi generate playground",
     "playground:preview": "nuxi preview playground"

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -28,9 +28,9 @@
   ],
   "scripts": {
     "build": "nuxt-build-module",
-    "stub": "nuxt-build-module build --stub",
+    "stub": "nuxt-build-module build --stub && pnpm dev:prepare",
     "dev": "pnpm dev:prepare && nuxi dev playground",
-    "prepare": "pnpm stub && nuxt-module-build prepare && nuxi prepare playground",
+    "dev:prepare": "nuxt-module-build prepare && nuxi prepare playground",
     "prepack": "nr build",
     "playground:build": "nuxi generate playground",
     "playground:preview": "nuxi preview playground"

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -188,7 +188,6 @@ export default defineNuxtModule<ModuleOptions>({
     await installModule('@vueuse/nuxt')
     await installModule('radix-vue/nuxt', {
       prefix: options.prefix,
-      priority: 100, // Set to the lowest priority
     })
 
     // composables

--- a/packages/nuxt/src/runtime/components/elements/Link.vue
+++ b/packages/nuxt/src/runtime/components/elements/Link.vue
@@ -1,11 +1,9 @@
 <script lang="ts">
 import type { PropType } from 'vue'
 import type { NLinkProps } from '../../types'
+import { NuxtLink } from '#components'
 import { isEqual } from 'ohash'
 import { defineComponent } from 'vue'
-
-// @ts-expect-error tsconfig
-import { NuxtLink } from '#components'
 
 export default defineComponent({
   inheritAttrs: false,

--- a/packages/nuxt/src/runtime/components/misc/ThemeSwitcher.vue
+++ b/packages/nuxt/src/runtime/components/misc/ThemeSwitcher.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useColorMode } from '#imports'
 import { useToggle } from '@vueuse/core'
 import { computed } from 'vue'
 import { useUnaSettings } from '../../composables/useUnaSettings'
@@ -8,9 +9,6 @@ import Button from '../elements/Button.vue'
 import Label from '../elements/Label.vue'
 import Popover from '../elements/popover/Popover.vue'
 import Separator from '../elements/Separator.vue'
-
-// @ts-expect-error tsconfig
-import { useColorMode } from '#imports'
 
 const colorMode = useColorMode()
 

--- a/packages/nuxt/src/runtime/composables/useUnaSettings.ts
+++ b/packages/nuxt/src/runtime/composables/useUnaSettings.ts
@@ -1,8 +1,8 @@
 import type { Ref } from 'vue'
 import type { UnaSettings } from '../types'
+import { useAppConfig } from '#imports'
 import { useStorage } from '@vueuse/core'
 import { defu } from 'defu'
-import { useAppConfig } from 'nuxt/app'
 import { watchEffect } from 'vue'
 import { useUnaThemes } from './useUnaThemes'
 

--- a/packages/nuxt/src/runtime/plugins/theme.client.ts
+++ b/packages/nuxt/src/runtime/plugins/theme.client.ts
@@ -1,8 +1,6 @@
+import { defineNuxtPlugin } from '#app'
 import { computed, watchEffect } from 'vue'
 import { useUnaSettings } from '../composables/useUnaSettings'
-
-// @ts-expect-error tsconfig
-import { defineNuxtPlugin } from '#app'
 
 let unaUIStyle: HTMLStyleElement
 

--- a/packages/nuxt/src/runtime/plugins/theme.server.ts
+++ b/packages/nuxt/src/runtime/plugins/theme.server.ts
@@ -1,7 +1,6 @@
-import { useUnaSettings } from '../composables/useUnaSettings'
-
-// @ts-expect-error tsconfig
 import { defineNuxtPlugin, useHead } from '#app'
+
+import { useUnaSettings } from '../composables/useUnaSettings'
 
 export default defineNuxtPlugin(() => {
   const { defaultSettings } = useUnaSettings()

--- a/packages/nuxt/tsconfig.json
+++ b/packages/nuxt/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,31 +1,5 @@
 {
-  "compilerOptions": { // Allow default imports from modules with no default export (nuxt module)
-    "target": "esnext",
-    "jsx": "preserve",
-    "lib": ["esnext", "dom"], // Required for path aliases (nuxt module)
-    "baseUrl": ".",
-    "rootDir": ".",
-    "module": "esnext",
-    "moduleResolution": "node",
-    "paths": {
-      "#app": ["node_modules/nuxt/dist/app"],
-      "#app/*": ["node_modules/nuxt/dist/app/*"],
-      "#components": ["./packages/nuxt/playground/.nuxt/components"],
-      "#imports": ["./packages/nuxt/playground/.nuxt/imports"],
-      "@una-ui/preset": ["./packages/preset/src/index.ts"]
-    },
-    "resolveJsonModule": true,
-    "types": [
-      "node"
-    ],
-    "strict": true,
-    "strictNullChecks": true,
-    "noUnusedLocals": true, // Required for path aliases (nuxt module)
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "skipDefaultLibCheck": true,
-    "skipLibCheck": true
-  },
+  "extends": "./packages/nuxt/tsconfig.json",
   "exclude": [
     "**/docs",
     "**/node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,10 @@
     "module": "esnext",
     "moduleResolution": "node",
     "paths": {
+      "#app": ["node_modules/nuxt/dist/app"],
+      "#app/*": ["node_modules/nuxt/dist/app/*"],
+      "#components": ["./packages/nuxt/playground/.nuxt/components"],
+      "#imports": ["./packages/nuxt/playground/.nuxt/imports"],
       "@una-ui/preset": ["./packages/preset/src/index.ts"]
     },
     "resolveJsonModule": true,


### PR DESCRIPTION
This removes the need for `/* @ts-expect-error */` and generally improves the DX.

I'm not sure if this is generally the recommended way to do this for modules, but it seems to work.