### PR TITLE
fix(Button): allow RouteLocationRaw for `to` prop

### DIFF
--- a/packages/nuxt/src/runtime/types/button.ts
+++ b/packages/nuxt/src/runtime/types/button.ts
@@ -1,4 +1,5 @@
 import type { HTMLAttributes } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
 
 interface Extensions {
   class?: HTMLAttributes['class']
@@ -55,7 +56,7 @@ export interface NButtonProps extends Extensions {
    * @example
    * to="/"
    */
-  to?: string
+  to?: RouteLocationRaw
   /**
    * Add a label to the button.
    *


### PR DESCRIPTION
This lets you use location object partials as links. e.g. 

```vue
<NButton label="Search" :to="{ query: { q: search }}" />
```
