### PR TITLE
fix(Button): Include search as possible type

### DIFF
--- a/packages/nuxt/src/runtime/types/input.ts
+++ b/packages/nuxt/src/runtime/types/input.ts
@@ -3,7 +3,7 @@ export interface NInputProps {
    *
    * @default null
    */
-  type?: 'text' | 'password' | 'email' | 'number' | 'tel' | 'url' | 'textarea' | ''
+  type?: 'text' | 'password' | 'email' | 'number' | 'tel' | 'url' | 'search' | 'textarea' | ''
 
   /**
    * Update the input status.


### PR DESCRIPTION
`search` was missing as a valid `type`.