### PR TITLE
feat(preset): add area-* shortcut as an alternative to tailwind size-*

### DIFF
--- a/packages/preset/src/_shortcuts/general.ts
+++ b/packages/preset/src/_shortcuts/general.ts
@@ -58,8 +58,15 @@ export const staticGeneral = {
 }
 
 export const dynamicGeneral: [RegExp, (params: RegExpExecArray) => string][] = [
-  // TODO: n-text-<color><-number><-number>
-  // [/^n-text(-(\S+))?$/, ([, , c = 'primary']) => `text-${c}-700 dark:text-${c}-400`],
+  // TODO: una-text-<color><-number><-number>
+  // [/^una-text(-(\S+))?$/, ([, , c = 'primary']) => `text-${c}-700 dark:text-${c}-400`],
+
+  /**
+   * Since we override the default `size` utility, we need to provide an alternative for it.
+   * @refer https://tailwindcss.com/docs/size
+   * @example area-100 -> w-100 h-100
+   */
+  [/^area-([^-]+)$/, ([, size = 'auto']) => `w-${size} h-${size}`],
 ]
 
 export const general = [


### PR DESCRIPTION
Since we override the `size-*` utility from [tailwind](https://tailwindcss.com/docs/size), we need to have an altertive to it. 

## Introducing `area-*`, set an element to a fixed width and height at the same time.

> [/^area-([^-]+)$/, ([, size = 'auto']) => `w-${size} h-${size}`]

eg: `area-100` or `area: 100`-> w-100 h-100

Docs: https://tailwindcss.com/docs/size
