### PR TITLE
docs: fix search and btns styles

### DIFF
--- a/docs/components/app/AppSearch.vue
+++ b/docs/components/app/AppSearch.vue
@@ -218,7 +218,7 @@ watch(Escape, () => {
     >
       <span class="flex items-center">
         <NIcon name="i-heroicons-magnifying-glass" sm:mr-3 />
-        <span class="max-w-20 w-auto flex items-center sm:max-w-auto">
+        <span class="max-w-20 w-auto flex items-center sm:max-w-fit">
           <p class="truncate text-ellipsis">Search documentation...</p>
         </span>
       </span>

--- a/docs/components/app/AppSearch.vue
+++ b/docs/components/app/AppSearch.vue
@@ -211,7 +211,7 @@ watch(Escape, () => {
 <template>
   <div class="z-5 flex items-center">
     <NButton
-      btn="!solid-gray block"
+      btn="!solid-white block"
       class="justify-between rounded-lg px-2 !text-muted font-normal md:w-80"
       aria-label="Search"
       @click="show = true"

--- a/docs/components/content/docs/DocsHero.vue
+++ b/docs/components/content/docs/DocsHero.vue
@@ -40,18 +40,21 @@ const { copy, copied } = useClipboard({ source })
         <NButton
           to="/getting-started"
           btn="solid"
-          class="h-2.9em rounded-full px-5.5 py-3 font-bold"
+          class="p-(3 6) font-bold"
+          rounded="full"
           label="Getting Started"
         />
         <NButton
           to="/components/accordion"
           btn="solid-gray"
-          class="h-2.9em rounded-full px-5.5 py-3 font-bold"
+          class="p-(3 6) font-bold"
+          rounded="full"
           label="View Components"
         />
         <NButton
           btn="solid-gray"
-          class="h-2.9em rounded-full px-5.5 py-3 font-bold"
+          class="p-(3 6) font-bold"
+          rounded="full"
           :class="{ 'text-primary-active': copied }"
           :label="source"
           :trailing="!copied ? 'i-heroicons-clipboard-document' : 'i-heroicons-check'"

--- a/docs/components/content/docs/DocsHero.vue
+++ b/docs/components/content/docs/DocsHero.vue
@@ -40,20 +40,20 @@ const { copy, copied } = useClipboard({ source })
         <NButton
           to="/getting-started"
           btn="solid"
-          class="p-(3 6) font-bold"
+          class="p-5.5 font-bold"
           rounded="full"
           label="Getting Started"
         />
         <NButton
           to="/components/accordion"
           btn="solid-gray"
-          class="p-(3 6) font-bold"
+          class="p-5.5 font-bold"
           rounded="full"
           label="View Components"
         />
         <NButton
           btn="solid-gray"
-          class="p-(3 6) font-bold"
+          class="p-5.5 font-bold"
           rounded="full"
           :class="{ 'text-primary-active': copied }"
           :label="source"

--- a/docs/components/content/docs/DocsHero.vue
+++ b/docs/components/content/docs/DocsHero.vue
@@ -40,18 +40,18 @@ const { copy, copied } = useClipboard({ source })
         <NButton
           to="/getting-started"
           btn="solid"
-          class="rounded-full px-5.5 py-3 font-bold"
+          class="h-2.9em rounded-full px-5.5 py-3 font-bold"
           label="Getting Started"
         />
         <NButton
           to="/components/accordion"
           btn="solid-gray"
-          class="rounded-full px-5.5 py-3 font-bold"
+          class="h-2.9em rounded-full px-5.5 py-3 font-bold"
           label="View Components"
         />
         <NButton
           btn="solid-gray"
-          class="rounded-full px-5.5 py-3 font-bold"
+          class="h-2.9em rounded-full px-5.5 py-3 font-bold"
           :class="{ 'text-primary-active': copied }"
           :label="source"
           :trailing="!copied ? 'i-heroicons-clipboard-document' : 'i-heroicons-check'"


### PR DESCRIPTION
We have a some shortcomings in `AppSearch.vue` styling and the small height of the main buttons
So this pr is solving it 

The reason for incorrect styles of `AppSearch.vue`  is: 

<img width="455" alt="Снимок экрана 2024-09-23 в 18 31 18" src="https://github.com/user-attachments/assets/dd5308ea-81f2-4bbe-9f88-23d4a3ebdcd6">

Screens: 

__The second screen is the solution__

<img width="1440" alt="Снимок экрана 2024-09-23 в 18 23 20" src="https://github.com/user-attachments/assets/20f0975e-a8ae-4f5d-a25d-abe20433ee8c">
<img width="1440" alt="Снимок экрана 2024-09-23 в 18 22 42" src="https://github.com/user-attachments/assets/d1fa5c68-0333-4152-ad19-e0ef15a532ef">



and now its work correctly in all devices

