### PR TITLE
build: increase available memory to docs builder [skip]

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "ui"
   ],
   "scripts": {
-    "build": "nuxt generate",
+    "build": "NODE_OPTIONS='--max-old-space-size=8192' nuxt generate",
     "dev": "nuxt dev",
     "preview": "nuxt preview",
     "c": "esno scripts/color-transition.ts",


### PR DESCRIPTION
There's probably a memory leak somewhere upstream.