### PR TITLE
fix: typo

### DIFF
--- a/packages/preset/src/_shortcuts/general.ts
+++ b/packages/preset/src/_shortcuts/general.ts
@@ -9,7 +9,7 @@ export const staticGeneral = {
   'text-muted': 'text-$c-muted-foreground',
 
   'text-accent': 'text-$c-accent-foreground',
-  'text-accent-forground': 'text-$c-accent',
+  'text-accent-foreground': 'text-$c-accent',
 
   'text-popover': 'text-$c-popover-foreground',
   'text-popover-foreground': 'text-$c-popover',


### PR DESCRIPTION
fix typo error from "forground" to "foregound'"