### PR TITLE
docs: fix typos and broken links

### DIFF
--- a/docs/components/content/examples/vue/checkbox/ExampleVueCheckboxReverse.vue
+++ b/docs/components/content/examples/vue/checkbox/ExampleVueCheckboxReverse.vue
@@ -7,7 +7,7 @@ const options = ref([
 </script>
 
 <template>
-  <div class="flex flex-wrap space-x-8">
+  <div class="flex flex-wrap gap-x-8 gap-y-6">
     <NCheckbox
       v-for="option in options"
       :key="option.label"

--- a/docs/components/content/examples/vue/checkbox/ExampleVueCheckboxSize.vue
+++ b/docs/components/content/examples/vue/checkbox/ExampleVueCheckboxSize.vue
@@ -34,7 +34,7 @@ const items = ref([
 </script>
 
 <template>
-  <div class="flex gap-4">
+  <div class="flex flex-wrap gap-4">
     <NCheckbox
       v-for="item in items"
       :key="item.size"

--- a/docs/content/3.components/accordion.md
+++ b/docs/content/3.components/accordion.md
@@ -3,7 +3,7 @@ description: 'A vertically stacked set of interactive headings that each reveal 
 badges:
   - value: Source
     icon: radix-icons:github-logo
-    to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/elements/Element.vue
+    to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/elements/Accordion.vue
     target: _blank
 ---
 

--- a/docs/content/3.components/card.md
+++ b/docs/content/3.components/card.md
@@ -83,33 +83,41 @@ badges:
 
 ## Presets
 
-@@@ ../packages/preset/src/_shortcuts/tooltip.ts [shortcuts/tooltip.ts]
+@@@ ../packages/preset/src/_shortcuts/card.ts [shortcuts/card.ts]
 
 ## Props
 
-@@@ ../packages/nuxt/src/runtime/types/tooltip.ts [types/tooltip.ts]
+@@@ ../packages/nuxt/src/runtime/types/card.ts [types/card.ts]
 
 ## Components
 
 :::CodeGroup
-::div{label="Tooltip.vue" icon="i-vscode-icons-file-type-vue"}
-@@@ ../packages/nuxt/src/runtime/components/elements/tooltip/Tooltip.vue
+::div{label="Card.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/elements/card/Card.vue
 
 ::
-::div{label="TooltipProvider.vue" icon="i-vscode-icons-file-type-vue"}
-@@@ ../packages/nuxt/src/runtime/components/elements/tooltip/TooltipProvider.vue
+::div{label="CardContent.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/elements/card/CardContent.vue
 
 ::
-::div{label="TooltipRoot.vue" icon="i-vscode-icons-file-type-vue"}
-@@@ ../packages/nuxt/src/runtime/components/elements/tooltip/TooltipRoot.vue
+::div{label="CardAbout.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/elements/card/CardAbout.vue
 
 ::
-::div{label="TooltipContent.vue" icon="i-vscode-icons-file-type-vue"}
-@@@ ../packages/nuxt/src/runtime/components/elements/tooltip/TooltipContent.vue
+::div{label="CardTitle.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/elements/card/CardTitle.vue
 
 ::
-::div{label="TooltipTrigger.vue" icon="i-vscode-icons-file-type-vue"}
-@@@ ../packages/nuxt/src/runtime/components/elements/tooltip/TooltipTrigger.vue
+::div{label="CardDescription.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/elements/card/CardDescription.vue
+
+::
+::div{label="CardHeader.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/elements/card/CardHeader.vue
+
+::
+::div{label="CardFooter.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/elements/card/CardFooter.vue
 
 ::
 :::

--- a/docs/content/3.components/dialog.md
+++ b/docs/content/3.components/dialog.md
@@ -2,7 +2,7 @@
 badges:
   - value: Source
     icon: radix-icons:github-logo
-    to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/elements/Dialog/dialog.vue
+    to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/elements/dialog/Dialog.vue
     target: _blank
   - value: API reference
     icon: /icons/radix-vue.svg

--- a/docs/content/3.components/form-group.md
+++ b/docs/content/3.components/form-group.md
@@ -3,7 +3,7 @@ description: 'A versatile wrapper for various form components such as `Input`, `
 badges:
   - value: Source
     icon: radix-icons:github-logo
-    to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/elements/forms/FormGroup.vue
+    to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/forms/FormGroup.vue
     target: _blank
 ---
 

--- a/docs/content/3.components/kbd.md
+++ b/docs/content/3.components/kbd.md
@@ -1,7 +1,7 @@
 ---
 description: 'Indicates input that is typically entered via keyboard.'
 badges:
-  - value: Github
+  - value: Source
     icon: radix-icons:github-logo
     to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/elements/Kbd.vue
     target: _blank

--- a/docs/content/3.components/link.md
+++ b/docs/content/3.components/link.md
@@ -40,10 +40,15 @@ badges:
 | `default` | -     | The content of the link. |
 
 ## Props
-@@@ ../packages/nuxt/src/runtime/types/link.ts
+@@@ ../packages/nuxt/src/runtime/types/link.ts [types/link.ts]
 
 ## Presets
-@@@ ../packages/preset/src/_shortcuts/link.ts
+@@@ ../packages/preset/src/_shortcuts/link.ts [shortcuts/link.ts]
 
 ## Components
+
+:::CodeGroup
+::div{label="Link.vue" icon="i-vscode-icons-file-type-vue"}
 @@@ ../packages/nuxt/src/runtime/components/elements/Link.vue
+
+::

--- a/docs/content/3.components/progress.md
+++ b/docs/content/3.components/progress.md
@@ -85,11 +85,11 @@ Configure the progress using the `una` prop and utility classes.
 
 ## Presets
 
-@@@ ../packages/preset/src/_shortcuts/progress.ts [shortcuts/tooltip.ts]
+@@@ ../packages/preset/src/_shortcuts/progress.ts [shortcuts/progress.ts]
 
 ## Props
 
-@@@ ../packages/nuxt/src/runtime/types/progress.ts [types/tooltip.ts]
+@@@ ../packages/nuxt/src/runtime/types/progress.ts [types/progress.ts]
 
 ## Components
 

--- a/docs/content/3.components/tabs.md
+++ b/docs/content/3.components/tabs.md
@@ -3,7 +3,7 @@ description: 'A set of layered sections of content—known as tab panels—that 
 badges:
   - value: Source
     icon: radix-icons:github-logo
-    to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/elements/tabs.vue
+    to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/elements/tabs/Tabs.vue
     target: _blank
   - value: API reference
     icon: /icons/radix-vue.svg


### PR DESCRIPTION
fix some typos and broken links in new docs