### PR TITLE
fix(Select): update trigger component and update examples

### DIFF
--- a/docs/components/content/examples/vue/select/ExampleVueSelectForm.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectForm.vue
@@ -5,7 +5,8 @@ const items = ['Evan You', 'Anthony Fu', 'Daniel Roe', 'Pooya Parsa', 'Sébastie
 
 <template>
   <div class="flex items-end">
-    <NFormGroup
+    <NFormField
+      name="contributor"
       label="Contributor"
       description="Select a contributor from the Vue community"
       :status="selected ? undefined : 'error'"
@@ -17,6 +18,6 @@ const items = ['Evan You', 'Anthony Fu', 'Daniel Roe', 'Pooya Parsa', 'Sébastie
         placeholder="Options"
         :items
       />
-    </NFormGroup>
+    </NFormField>
   </div>
 </template>

--- a/docs/components/content/examples/vue/select/ExampleVueSelectSlots.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectSlots.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+const items = [
+  {
+    name: 'Evan You',
+    avatar: 'https://avatars.githubusercontent.com/u/499550?v=4',
+  },
+  {
+    name: 'Anthony Fu',
+    avatar: 'https://avatars.githubusercontent.com/u/11247099?v=4',
+  },
+  {
+    name: 'Daniel Roe',
+    avatar: 'https://avatars.githubusercontent.com/u/28706372?v=4',
+  },
+]
+const selected = ref(items[0])
+</script>
+
+<template>
+  <div class="max-w-50">
+    <NSelect
+      v-model="selected"
+      :items
+      placeholder="Select Contributor"
+      label="Vue Community"
+      :_select-trigger="{
+        una: {
+          selectTriggerTrailingIcon: 'i-lucide-chevron-down',
+        },
+      }"
+    >
+      <template #label="{ label }">
+        <div class="flex flex-col space-y-0.5">
+          <span class="text-primary">{{ label }}</span>
+          <span class="text-xs text-muted">Mini example list of contributors</span>
+        </div>
+      </template>
+      <template #item="{ item }">
+        <div class="flex items-center space-x-2">
+          <img
+            :src="item.avatar"
+            :alt="item.name"
+            class="h-6 w-6 rounded-full"
+          >
+          <span>{{ item.name }}</span>
+        </div>
+      </template>
+      <template #value="{ value }">
+        <div class="flex items-center space-x-2">
+          <img
+            :src="value?.avatar"
+            :alt="value?.name"
+            class="h-6 w-6 rounded-full"
+          >
+          <span>{{ value?.name }}</span>
+        </div>
+      </template>
+    </NSelect>
+  </div>
+</template>

--- a/docs/content/3.components/select.md
+++ b/docs/content/3.components/select.md
@@ -17,10 +17,10 @@ badges:
 | Name           | Default | Type      | Description                                                                                                     |
 | -------------- | ------- | --------- | --------------------------------------------------------------------------------------------------------------- |
 | `items`        | -       | `array`   | Set the select items.                                                                                           |
-| `placeholder`  | -       | `string`  | The content that will be rendered inside the SelectValue when no value or defaultValue is set.                  |
+| `placeholder`  | -       | `string`  | The content that will be rendered inside the `SelectValue` when no `value` or `defaultValue` is set.            |
 | `label`        | -       | `string`  | Set the select items label.                                                                                     |
 | `defaultOpen`  | -       | `boolean` | The open state of the select when it is initially rendered. Use when you do not need to control its open state. |
-| `defaultValue` | -       | `string`  | The value of the select when initially rendered. Use when you do not need to control the state of the Select    |
+| `defaultValue` | -       | `string`  | The value of the select when initially rendered. Use when you do not need to control the state of the `Select`  |
 | `open`         | -       | `boolean` | The controlled open state of the Select. Can be bind as `v-model:open`.                                         |
 | `modelValue`   | -       | `string`  | The controlled value of the Select. Can be bind as `v-model`.                                                   |
 
@@ -70,22 +70,20 @@ Control the attribute value to be displayed in the select and the item.
 ::
 :::
 
-### Form Group
+### Form Field
 
-You can use the `select` component inside the `form-group` component, or you can use it with the `label` component.
+The `NSelect` component can be easily embedded within the `NFormField` component.
 
 :::CodeGroup
 ::div{label="Preview" preview}
-:ExampleVueSelectLabel
+:ExampleVueSelectForm
 ::
 ::div{label="Code"}
-@@@ ./components/content/examples/vue/select/ExampleVueSelectLabel.vue
+@@@ ./components/content/examples/vue/select/ExampleVueSelectForm.vue
 ::
 :::
 
-:read-more{to="/components/form-group" title="Form-group component" target="_blank"}
-
-:read-more{to="/components/label" title="Label component" target="_blank"}
+:read-more{to="/components/form" title="Form component" target="_blank"}
 
 ### Variant and Color
 
@@ -134,6 +132,15 @@ Adjust the select size without limits. Use `breakpoints` (e.g., `sm:sm`, `xs:lg`
 | `label`   | `label` | The label slot.   |
 | `item`    | `item`  | The item slot.    |
 | `group`   | `items` | The group slot.   |
+
+:::CodeGroup
+::div{label="Preview"}
+:ExampleVueSelectSlots
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/select/ExampleVueSelectSlots.vue
+::
+:::
 
 ## Presets
 

--- a/packages/nuxt/src/runtime/components/forms/select/SelectTrigger.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectTrigger.vue
@@ -37,7 +37,7 @@ const statusClassVariants = computed(() => {
     success: props.una?.selectTriggerSuccessIcon ?? 'select-trigger-success-icon',
     warning: props.una?.selectTriggerWarningIcon ?? 'select-trigger-warning-icon',
     error: props.una?.selectTriggerErrorIcon ?? 'select-trigger-error-icon',
-    default: 'select-trigger-trailing-icon',
+    default: props.una?.selectTriggerTrailingIcon ?? 'select-trigger-trailing-icon',
   }
 
   return {

--- a/packages/preset/src/_shortcuts/select.ts
+++ b/packages/preset/src/_shortcuts/select.ts
@@ -13,7 +13,7 @@ export const staticSelect: Record<`${SelectPrefix}-${string}` | SelectPrefix, st
 
   // components
   'select-root': '',
-  'select-trigger': 'w-full', // [&>span]:line-clamp-1
+  'select-trigger': 'w-full [&>span]:truncate',
   'select-trigger-trailing-icon': 'i-lucide-chevrons-up-down !text-1.042em',
   'select-trigger-trailing': 'ml-auto',
   'select-trigger-leading': '',


### PR DESCRIPTION
hi @phojie !

- the first thing I did was add `truncate` style to `span` in `trigger` because with a fixed width, the content goes out of bounds
- also had to make it easy to change the  `trailingIcon`
- and I added an example with `slots` 😉