### PR TITLE
feat(Table): add emit functionality on row click; improve types

### DIFF
--- a/docs/content/3.components/table.md
+++ b/docs/content/3.components/table.md
@@ -47,6 +47,7 @@ Row selection allows you to select rows in the table. This is useful when you wa
 | `enableSubRowSelection`   | `false` | `boolean` | Enable sub row selection.                         |
 | `@select`                 | -       | `event`   | Emitted when a row is selected.                   |
 | `@select-all`             | -       | `event`   | Emitted when all rows are selected.               |
+| `@row`                    | -       | `event`   | Emitted when a row is clicked.                    |
 
 :::CodeGroup
 ::div{label="Preview"}

--- a/docs/content/3.components/table.md
+++ b/docs/content/3.components/table.md
@@ -45,9 +45,13 @@ Row selection allows you to select rows in the table. This is useful when you wa
 | `enableMultiRowSelection` | `true`  | `boolean`    | Enable multiple row selection.                    |
 | `rowId`                   | `id`    | `string`     | Row id to uniquely identify each row.             |
 | `enableSubRowSelection`   | `false` | `boolean`    | Enable sub row selection.                         |
-| `@select`                 | -       | `event`      | Emitted when a row is selected.                   |
+| `@select`                 | -       | `event,`     | Emitted when a row is selected.                   |
 | `@select-all`             | -       | `event`      | Emitted when all rows are selected.               |
 | `@row`                    | -       | `event, row` | Emitted when a row is clicked.                    |
+
+::alert{type="warning"}
+When using the `@row` event, you should stop propagation if you have interactive elements like buttons or links inside the row to prevent triggering the row click event.
+::
 
 :::CodeGroup
 ::div{label="Preview"}

--- a/docs/content/3.components/table.md
+++ b/docs/content/3.components/table.md
@@ -38,16 +38,16 @@ badges:
 
 Row selection allows you to select rows in the table. This is useful when you want to select rows in the table.
 
-| Prop                      | Default | Type      | Description                                       |
-| ------------------------- | ------- | --------- | ------------------------------------------------- |
-| `rowSelection`            | -       | `object`  | Selected row state, can be binded with `v-model`. |
-| `enableRowSelection`      | `false` | `boolean` | Enable row selection.                             |
-| `enableMultiRowSelection` | `true`  | `boolean` | Enable multiple row selection.                    |
-| `rowId`                   | `id`    | `string`  | Row id to uniquely identify each row.             |
-| `enableSubRowSelection`   | `false` | `boolean` | Enable sub row selection.                         |
-| `@select`                 | -       | `event`   | Emitted when a row is selected.                   |
-| `@select-all`             | -       | `event`   | Emitted when all rows are selected.               |
-| `@row`                    | -       | `event`   | Emitted when a row is clicked.                    |
+| Prop                      | Default | Type         | Description                                       |
+| ------------------------- | ------- | ------------ | ------------------------------------------------- |
+| `rowSelection`            | -       | `object`     | Selected row state, can be binded with `v-model`. |
+| `enableRowSelection`      | `false` | `boolean`    | Enable row selection.                             |
+| `enableMultiRowSelection` | `true`  | `boolean`    | Enable multiple row selection.                    |
+| `rowId`                   | `id`    | `string`     | Row id to uniquely identify each row.             |
+| `enableSubRowSelection`   | `false` | `boolean`    | Enable sub row selection.                         |
+| `@select`                 | -       | `event`      | Emitted when a row is selected.                   |
+| `@select-all`             | -       | `event`      | Emitted when all rows are selected.               |
+| `@row`                    | -       | `event, row` | Emitted when a row is clicked.                    |
 
 :::CodeGroup
 ::div{label="Preview"}

--- a/packages/nuxt/playground/pages/components/table.vue
+++ b/packages/nuxt/playground/pages/components/table.vue
@@ -113,7 +113,7 @@ const pokemon = computed(() => data.value?.results ?? [])
       :row-count="data?.results.length"
       :page-count="data?.count"
       enable-row-selection
-      @row="(row) => {
+      @row="(_, row) => {
         console.log('click-row', row)
       }"
     />

--- a/packages/nuxt/playground/pages/components/table.vue
+++ b/packages/nuxt/playground/pages/components/table.vue
@@ -113,6 +113,9 @@ const pokemon = computed(() => data.value?.results ?? [])
       :row-count="data?.results.length"
       :page-count="data?.count"
       enable-row-selection
+      @row="(row) => {
+        console.log('click-row', row)
+      }"
     />
 
     <div class="flex items-center justify-end py-4 space-x-2">

--- a/packages/nuxt/src/runtime/components/data/table/Table.vue
+++ b/packages/nuxt/src/runtime/components/data/table/Table.vue
@@ -44,7 +44,12 @@ const props = withDefaults(defineProps <NTableProps<TData, TValue>>(), {
   enableSortingRemoval: true,
 })
 
-const emit = defineEmits(['select', 'selectAll', 'expand'])
+const emit = defineEmits<{
+  select: [row: TData]
+  selectAll: [rows: TData[]]
+  expand: [row: TData]
+  row: [event: Event, row: TData]
+}>()
 
 const slots = defineSlots()
 
@@ -340,10 +345,7 @@ defineExpose({
                   :data-state="row.getIsSelected() && 'selected'"
                   :una
                   v-bind="props._tableRow"
-                  @click="(e) => {
-                    props.onRow?.(e, row);
-                    props._tableRow?.onClick?.(e, row);
-                  }"
+                  @click="emit('row', $event, row.original)"
                 >
                   <slot
                     name="row"

--- a/packages/nuxt/src/runtime/components/data/table/Table.vue
+++ b/packages/nuxt/src/runtime/components/data/table/Table.vue
@@ -7,8 +7,10 @@ import type {
   GroupingState,
   Header,
   PaginationState,
+  Row,
   RowSelectionState,
   SortingState,
+  Table,
   VisibilityState,
 } from '@tanstack/vue-table'
 import type { NTableProps } from '../../../types'
@@ -78,22 +80,28 @@ const columnsWithMisc = computed(() => {
         {
           accessorKey: 'selection',
           header: props.enableMultiRowSelection
-            ? ({ table }: any) => h(Checkbox, {
+            ? ({ table }: { table: Table<TData> }) => h(Checkbox, {
                 'modelValue': table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate'),
                 'onUpdate:modelValue': (value: boolean | 'indeterminate' | null) => {
                   table.toggleAllPageRowsSelected(!!value)
-                  emit('selectAll', table.getRowModel().rows)
+                  emit('selectAll', table.getRowModel().rows.map(row => row.original))
                 },
                 'areaLabel': 'Select all rows',
+                'onClick': (event: Event) => {
+                  event.stopPropagation()
+                },
               })
             : '',
-          cell: ({ row }: any) => h(Checkbox, {
+          cell: ({ row }: { row: Row<TData> }) => h(Checkbox, {
             'modelValue': row.getIsSelected() ?? false,
             'onUpdate:modelValue': (value: boolean | 'indeterminate' | null) => {
               row.toggleSelected(!!value)
-              emit('select', row)
+              emit('select', row.original)
             },
             'areaLabel': 'Select row',
+            'onClick': (event: Event) => {
+              event.stopPropagation()
+            },
           }),
           enableSorting: false,
         },

--- a/packages/nuxt/src/runtime/components/data/table/Table.vue
+++ b/packages/nuxt/src/runtime/components/data/table/Table.vue
@@ -340,6 +340,7 @@ defineExpose({
                   :data-state="row.getIsSelected() && 'selected'"
                   :una
                   v-bind="props._tableRow"
+                  @click="props.onRow?.(row, $event) || props._tableRow?.onClick?.(row, $event)"
                 >
                   <slot
                     name="row"

--- a/packages/nuxt/src/runtime/components/data/table/Table.vue
+++ b/packages/nuxt/src/runtime/components/data/table/Table.vue
@@ -340,7 +340,10 @@ defineExpose({
                   :data-state="row.getIsSelected() && 'selected'"
                   :una
                   v-bind="props._tableRow"
-                  @click="props.onRow?.(row, $event) || props._tableRow?.onClick?.(row, $event)"
+                  @click="(e) => {
+                    props.onRow?.(e, row);
+                    props._tableRow?.onClick?.(e, row);
+                  }"
                 >
                   <slot
                     name="row"

--- a/packages/nuxt/src/runtime/components/data/table/TableRow.vue
+++ b/packages/nuxt/src/runtime/components/data/table/TableRow.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import type { NTableRowProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { cn } from '../../../utils'
 
 const props = defineProps<NTableRowProps>()
+
+const rootProps = reactiveOmit(props, ['una', 'class'])
 </script>
 
 <template>
@@ -12,7 +15,7 @@ const props = defineProps<NTableRowProps>()
       props.una?.tableRow,
       props.class,
     )"
-    v-bind="$attrs"
+    v-bind="{ ...rootProps, ...$attrs }"
   >
     <slot />
   </tr>

--- a/packages/nuxt/src/runtime/types/table.ts
+++ b/packages/nuxt/src/runtime/types/table.ts
@@ -2,6 +2,7 @@ import type {
   ColumnDef,
   CoreOptions,
   GroupColumnDef,
+  Row,
 } from '@tanstack/vue-table'
 import type { HTMLAttributes } from 'vue'
 import type { NProgressProps } from './progress'
@@ -117,7 +118,7 @@ export interface NTableProps<TData, TValue> extends Omit<CoreOptions<TData>, 'da
   _tableFooter?: NTableFooterProps
   _tableBody?: NTableBodyProps
   _tableCaption?: NTableCaptionProps
-  _tableRow?: NTableRowProps
+  _tableRow?: NTableRowProps<TData>
   _tableCell?: NTableCellProps
   _tableEmpty?: NTableEmptyProps
   _tableLoading?: NTableLoadingProps
@@ -131,6 +132,11 @@ export interface NTableProps<TData, TValue> extends Omit<CoreOptions<TData>, 'da
    * @see https://github.com/una-ui/una-ui/blob/main/packages/preset/src/_shortcuts/table.ts
    */
   una?: NTableUnaProps & NScrollAreaUnaProps
+
+  /**
+   * Trigger when row is clicked
+   */
+  onRow?: NTableRowProps<TData>['onClick']
 }
 
 export interface NTableBodyProps {
@@ -159,10 +165,14 @@ export interface NTableFooterProps {
   una?: Pick<NTableUnaProps, 'tableFooter'>
 }
 
-export interface NTableRowProps {
+export interface NTableRowProps<TData = any> {
   class?: HTMLAttributes['class']
-
   una?: Pick<NTableUnaProps, 'tableRow'>
+
+  /**
+   * Trigger when row is clicked
+   */
+  onClick?: (row: Row<TData>, e: MouseEvent) => void
 }
 
 export interface NTableCellProps {

--- a/packages/nuxt/src/runtime/types/table.ts
+++ b/packages/nuxt/src/runtime/types/table.ts
@@ -172,7 +172,7 @@ export interface NTableRowProps<TData = any> {
   /**
    * Trigger when row is clicked
    */
-  onClick?: (row: Row<TData>, e: MouseEvent) => void
+  onClick?: (e: MouseEvent, row: Row<TData>) => void
 }
 
 export interface NTableCellProps {

--- a/packages/nuxt/src/runtime/types/table.ts
+++ b/packages/nuxt/src/runtime/types/table.ts
@@ -2,7 +2,6 @@ import type {
   ColumnDef,
   CoreOptions,
   GroupColumnDef,
-  Row,
 } from '@tanstack/vue-table'
 import type { HTMLAttributes } from 'vue'
 import type { NProgressProps } from './progress'
@@ -118,7 +117,7 @@ export interface NTableProps<TData, TValue> extends Omit<CoreOptions<TData>, 'da
   _tableFooter?: NTableFooterProps
   _tableBody?: NTableBodyProps
   _tableCaption?: NTableCaptionProps
-  _tableRow?: NTableRowProps<TData>
+  _tableRow?: NTableRowProps
   _tableCell?: NTableCellProps
   _tableEmpty?: NTableEmptyProps
   _tableLoading?: NTableLoadingProps
@@ -132,11 +131,6 @@ export interface NTableProps<TData, TValue> extends Omit<CoreOptions<TData>, 'da
    * @see https://github.com/una-ui/una-ui/blob/main/packages/preset/src/_shortcuts/table.ts
    */
   una?: NTableUnaProps & NScrollAreaUnaProps
-
-  /**
-   * Trigger when row is clicked
-   */
-  onRow?: NTableRowProps<TData>['onClick']
 }
 
 export interface NTableBodyProps {
@@ -165,14 +159,9 @@ export interface NTableFooterProps {
   una?: Pick<NTableUnaProps, 'tableFooter'>
 }
 
-export interface NTableRowProps<TData = any> {
+export interface NTableRowProps {
   class?: HTMLAttributes['class']
   una?: Pick<NTableUnaProps, 'tableRow'>
-
-  /**
-   * Trigger when row is clicked
-   */
-  onClick?: (e: MouseEvent, row: Row<TData>) => void
 }
 
 export interface NTableCellProps {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new row click event that enhances table interactivity, enabling customizable responses when a row is clicked.
  - Updated event handling within the table component for greater flexibility, allowing the application to log clicked row information.
  - Revised the table documentation to include details on the new row click event.
  
- **Bug Fixes**
  - Removed the `una` property from the `NTableRowProps` interface to simplify the component's structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->