### PR TITLE
feat(Table): enhance `_tableRow` prop to accept a function for dynamic row attributes

### DIFF
--- a/packages/nuxt/src/runtime/components/data/table/Table.vue
+++ b/packages/nuxt/src/runtime/components/data/table/Table.vue
@@ -210,6 +210,13 @@ function getHeaderColumnFiltersCount(headers: Header<unknown, unknown>[]): numbe
   return count
 }
 
+function getRowAttrs(data?: TData) {
+  if (typeof props._tableRow === 'function') {
+    return props._tableRow(data)
+  }
+  return props._tableRow
+}
+
 defineExpose({
   ...table,
 })
@@ -242,7 +249,7 @@ defineExpose({
               v-for="headerGroup in table.getHeaderGroups()"
               :key="headerGroup.id"
               :una
-              v-bind="props._tableRow"
+              v-bind="getRowAttrs()"
             >
               <!-- headers -->
               <TableHead
@@ -301,7 +308,7 @@ defineExpose({
                 v-if="getHeaderColumnFiltersCount(headerGroup.headers) > 0 || enableColumnFilters"
                 data-filter="true"
                 :una
-                v-bind="props._tableRow"
+                v-bind="getRowAttrs()"
               >
                 <TableHead
                   v-for="header in headerGroup.headers"
@@ -352,7 +359,7 @@ defineExpose({
                 <TableRow
                   :data-state="row.getIsSelected() && 'selected'"
                   :una
-                  v-bind="props._tableRow"
+                  v-bind="getRowAttrs(row.original)"
                   @click="emit('row', $event, row.original)"
                 >
                   <slot
@@ -384,7 +391,7 @@ defineExpose({
                 <TableRow
                   v-if="row.getIsExpanded() && $slots.expanded"
                   :una
-                  v-bind="props._tableRow"
+                  v-bind="getRowAttrs(row.original)"
                 >
                   <TableCell
                     :colspan="row.getAllCells().length"
@@ -422,7 +429,7 @@ defineExpose({
               <TableRow
                 v-if="footerGroup.headers.length > 0"
                 :una
-                v-bind="props._tableRow"
+                v-bind="getRowAttrs()"
               >
                 <template
                   v-for="header in footerGroup.headers"

--- a/packages/nuxt/src/runtime/components/data/table/TableRow.vue
+++ b/packages/nuxt/src/runtime/components/data/table/TableRow.vue
@@ -13,6 +13,7 @@ const rootProps = reactiveOmit(props, ['una', 'class'])
 
 <template>
   <Primitive
+    role="row"
     :class="cn(
       'table-row',
       props.una?.tableRow,
@@ -23,3 +24,10 @@ const rootProps = reactiveOmit(props, ['una', 'class'])
     <slot />
   </Primitive>
 </template>
+
+<style>
+/* the builtin unocss utility is overwritten, so it has to be defined here */
+.table-row {
+  display: table-row;
+}
+</style>

--- a/packages/nuxt/src/runtime/types/table.ts
+++ b/packages/nuxt/src/runtime/types/table.ts
@@ -118,7 +118,7 @@ export interface NTableProps<TData, TValue> extends Omit<CoreOptions<TData>, 'da
   _tableFooter?: NTableFooterProps
   _tableBody?: NTableBodyProps
   _tableCaption?: NTableCaptionProps
-  _tableRow?: NTableRowProps
+  _tableRow?: NTableRowProps | ((row?: TData) => NTableRowProps)
   _tableCell?: NTableCellProps
   _tableEmpty?: NTableEmptyProps
   _tableLoading?: NTableLoadingProps


### PR DESCRIPTION
This allows making the entire row into an accessible link via

```vue
<NTable
  :_table-row="(row) => row && {
    as: markRaw(NLink),
    to: `#${row.id}`
  }"
 />
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic customization for table row attributes, allowing table rows to adjust based on the underlying data.
  - Enhanced table accessibility by explicitly defining row roles and enforcing consistent visual styling.

- **Refactor**
  - Updated configuration options for table rows to support both static and dynamic attribute definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->