### PR TITLE
fix(config): resolve config paths relative to the current file

### DIFF
--- a/uno.config.ts
+++ b/uno.config.ts
@@ -1,3 +1,7 @@
+import { readdirSync } from 'node:fs'
+import { dirname, extname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import {
   defineConfig,
   presetAttributify,
@@ -11,6 +15,21 @@ import { presetAnimations } from 'unocss-preset-animations'
 import extratorUna from './packages/extractor-vue-script/src/index'
 import presetUna from './packages/preset/src/index'
 import prefixes from './packages/preset/src/prefixes'
+
+/**
+ * Search a directory for all files with a `.ts` extension
+ * and return their absolute paths.
+ *
+ * This is a workaround for unocss/unocss#2613
+ *
+ * @param dir The directory to read
+ * @returns An array of file paths
+ */
+function getAllConfigFiles(dir: string): string[] {
+  const basedir = join(dirname(fileURLToPath(import.meta.url)), dir)
+  const files = readdirSync(basedir)
+  return files.filter(file => extname(file) === '.ts').map(file => join(basedir, file))
+}
 
 export default defineConfig({
   safelist: [
@@ -43,43 +62,6 @@ export default defineConfig({
     }),
   ],
   configDeps: [
-    './packages/preset/src/_shortcuts/aspect-ratio.ts',
-    './packages/preset/src/_shortcuts/navigation-menu.ts',
-    './packages/preset/src/_shortcuts/sidebar.ts',
-    './packages/preset/src/_shortcuts/sheet.ts',
-    './packages/preset/src/_shortcuts/toast.ts',
-    './packages/preset/src/_shortcuts/form.ts',
-    './packages/preset/src/_shortcuts/radio-group.ts',
-    './packages/preset/src/_shortcuts/collapsible.ts',
-    './packages/preset/src/_shortcuts/calendar.ts',
-    './packages/preset/src/_shortcuts/pagination.ts',
-    './packages/preset/src/_shortcuts/label.ts',
-    './packages/preset/src/_shortcuts/dropdown-menu.ts',
-    './packages/preset/src/_shortcuts/breadcrumb.ts',
-    './packages/preset/src/_shortcuts/table.ts',
-    './packages/preset/src/_shortcuts/card.ts',
-    './packages/preset/src/_shortcuts/tabs.ts',
-    './packages/preset/src/_shortcuts/separator.ts',
-    './packages/preset/src/_shortcuts/select.ts',
-    './packages/preset/src/_shortcuts/skeleton.ts',
-    './packages/preset/src/_shortcuts/progress.ts',
-    './packages/preset/src/_shortcuts/slider.ts',
-    './packages/preset/src/_shortcuts/checkbox.ts',
-    './packages/preset/src/_shortcuts/link.ts',
-    './packages/preset/src/_shortcuts/kbd.ts',
-    './packages/preset/src/_shortcuts/indicator.ts',
-    './packages/preset/src/_shortcuts/avatar-group.ts',
-    './packages/preset/src/_shortcuts/avatar.ts',
-    './packages/preset/src/_shortcuts/badge.ts',
-    './packages/preset/src/_shortcuts/alert.ts',
-    './packages/preset/src/_shortcuts/input.ts',
-    './packages/preset/src/_shortcuts/btn.ts',
-    './packages/preset/src/_shortcuts/form-group.ts',
-    './packages/preset/src/_shortcuts/accordion.ts',
-    './packages/preset/src/_shortcuts/switch.ts',
-    './packages/preset/src/_shortcuts/dialog.ts',
-    './packages/preset/src/_shortcuts/general.ts',
-    './packages/preset/src/_shortcuts/index.ts',
-    './packages/preset/src/index.ts',
+    ...getAllConfigFiles('./packages/preset/src/_shortcuts'),
   ],
 })


### PR DESCRIPTION
This fixes dev-time shortcut reloading and is a workaround for unocss/unocss#2613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved configuration management by automatically including all relevant shortcut files, reducing manual updates and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->