### PR TITLE
fix(nuxt): unify una prop type definitions across all subcomponents

### DIFF
--- a/packages/nuxt/src/runtime/components/elements/dialog/DialogContent.vue
+++ b/packages/nuxt/src/runtime/components/elements/dialog/DialogContent.vue
@@ -62,7 +62,6 @@ const contentEvents = computed(() => {
         v-if="showClose"
         v-bind="_dialogClose"
         class="dialog-close"
-        :una
       />
     </DialogContent>
   </DialogPortal>

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenu.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenu.vue
@@ -54,7 +54,7 @@ const [DefineMenuSub, ReuseMenuSub] = createReusableTemplate<NDropdownMenuProps>
           <DropdownMenuLabel
             :size
             :inset
-            :una="forwarded.una?.dropdownMenuLabel"
+            :una
             v-bind="forwarded._dropdownMenuLabel"
           >
             <slot name="menu-label">
@@ -62,14 +62,14 @@ const [DefineMenuSub, ReuseMenuSub] = createReusableTemplate<NDropdownMenuProps>
             </slot>
           </DropdownMenuLabel>
           <DropdownMenuSeparator
-            :una="forwarded.una?.dropdownMenuSeparator"
+            :una
             v-bind="forwarded._dropdownMenuSeparator"
           />
         </template>
 
         <slot name="group" :items>
           <DropdownMenuGroup
-            :una="forwarded.una?.dropdownMenuGroup"
+            :una
             v-bind="forwarded._dropdownMenuGroup"
           >
             <slot name="items" :items>
@@ -85,7 +85,7 @@ const [DefineMenuSub, ReuseMenuSub] = createReusableTemplate<NDropdownMenuProps>
                     :size
                     :inset
                     :dropdown-menu-item
-                    :una="forwarded.una?.dropdownMenuItem"
+                    :una
                     :_dropdown-menu-shortcut
                     v-bind="{ ...item, ...forwarded._dropdownMenuItem, ...item._dropdownMenuItem }"
                   />
@@ -93,7 +93,7 @@ const [DefineMenuSub, ReuseMenuSub] = createReusableTemplate<NDropdownMenuProps>
 
                 <DropdownMenuSeparator
                   v-else-if="!item.label && !item.items"
-                  :una="forwarded.una?.dropdownMenuSeparator"
+                  :una
                   v-bind="{ ...forwarded._dropdownMenuSeparator, ...item._dropdownMenuSeparator }"
                 />
 
@@ -119,26 +119,26 @@ const [DefineMenuSub, ReuseMenuSub] = createReusableTemplate<NDropdownMenuProps>
       <DropdownMenuLabel
         :size
         :inset
-        :una="forwarded.una?.dropdownMenuLabel"
+        :una
         v-bind="{ ...forwarded._dropdownMenuLabel, ...subProps._dropdownMenuLabel }"
       >
         {{ subProps.menuLabel }}
       </DropdownMenuLabel>
       <DropdownMenuSeparator
-        :una="forwarded.una?.dropdownMenuSeparator"
+        :una
         v-bind="{ ...forwarded._dropdownMenuSeparator, ...subProps._dropdownMenuSeparator }"
       />
     </template>
 
     <DropdownMenuGroup
-      :una="forwarded.una?.dropdownMenuGroup"
+      :una
       v-bind="{ ...forwarded._dropdownMenuGroup, ...subProps._dropdownMenuGroup }"
     >
       <DropdownMenuSub>
         <DropdownMenuSubTrigger
           :size
           :inset
-          :una="forwarded.una?.dropdownMenuSubTrigger"
+          :una
           :dropdown-menu-item
           v-bind="omitProps({
             ...subProps,
@@ -152,7 +152,7 @@ const [DefineMenuSub, ReuseMenuSub] = createReusableTemplate<NDropdownMenuProps>
         <DropdownMenuPortal>
           <DropdownMenuSubContent
             v-bind="subProps._dropdownMenuSubContent"
-            :una="forwarded.una?.dropdownMenuSubContent"
+            :una
           >
             <template
               v-for="subItem in subProps.items"
@@ -164,7 +164,7 @@ const [DefineMenuSub, ReuseMenuSub] = createReusableTemplate<NDropdownMenuProps>
                 :inset
                 :dropdown-menu-item
                 :_dropdown-menu-shortcut
-                :una="forwarded.una?.dropdownMenuItem"
+                :una
                 v-bind="{ ...subItem, ...forwarded._dropdownMenuItem, ...subItem._dropdownMenuItem }"
               >
                 {{ subItem.label }}
@@ -172,7 +172,7 @@ const [DefineMenuSub, ReuseMenuSub] = createReusableTemplate<NDropdownMenuProps>
 
               <DropdownMenuSeparator
                 v-else-if="!subItem.label && !subItem.items"
-                :una="forwarded.una?.dropdownMenuSeparator"
+                :una
                 v-bind="{ ...forwarded._dropdownMenuSeparator, ...subItem._dropdownMenuSeparator }"
               />
 

--- a/packages/nuxt/src/runtime/components/elements/tooltip/Tooltip.vue
+++ b/packages/nuxt/src/runtime/components/elements/tooltip/Tooltip.vue
@@ -46,7 +46,7 @@ const forwarded = useForwardPropsEmits(rootProps, emits)
         :size
         :tooltip
         :disabled
-        :una="una?.tooltipContent"
+        :una
       >
         <slot name="content">
           {{ content }}

--- a/packages/nuxt/src/runtime/components/forms/form/FormField.vue
+++ b/packages/nuxt/src/runtime/components/forms/form/FormField.vue
@@ -38,6 +38,7 @@ const statusClassVariants = computed(() => {
       :class="cn(
         props.class,
       )"
+      :una
     >
       <slot name="top">
         <div

--- a/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuContentItem.vue
+++ b/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuContentItem.vue
@@ -14,6 +14,7 @@ const forwarded = useForwardPropsEmits(props, emits)
 <template>
   <NavigationMenuLink
     v-bind="forwarded"
+    :una
     :class="cn(
       'navigation-menu-content-item',
       props.una?.navigationMenuContentItem,

--- a/packages/nuxt/src/runtime/types/avatar.ts
+++ b/packages/nuxt/src/runtime/types/avatar.ts
@@ -40,7 +40,7 @@ export interface NAvatarRootProps extends AvatarRootProps, BaseProps {
    */
   avatar?: HTMLAttributes['class']
 
-  una?: NAvatarUnaProps['avatarRoot']
+  una?: Pick<NAvatarUnaProps, 'avatarRoot'>
 }
 
 export interface NAvatarAvatarFallbackProps extends AvatarFallbackProps, BaseProps {
@@ -58,13 +58,13 @@ export interface NAvatarAvatarFallbackProps extends AvatarFallbackProps, BasePro
    */
   icon?: boolean
 
-  una?: NAvatarUnaProps['avatarFallback']
+  una?: Pick<NAvatarUnaProps, 'avatarFallback' | 'avatarLabel' | 'avatarIcon'>
 }
 
 export interface NAvatarImageProps extends Omit<AvatarImageProps, 'src'>, BaseProps {
   src?: string
   alt?: string
-  una?: NAvatarUnaProps['avatarImage']
+  una?: Pick<NAvatarUnaProps, 'avatarImage'>
 }
 
 export interface NAvatarUnaProps {

--- a/packages/nuxt/src/runtime/types/dialog.ts
+++ b/packages/nuxt/src/runtime/types/dialog.ts
@@ -42,11 +42,11 @@ interface BaseExtensions {
 }
 
 export interface NDialogTitleProps extends DialogTitleProps, BaseExtensions {
-  una?: NDialogUnaProps['dialogTitle']
+  una?: Pick<NDialogUnaProps, 'dialogTitle'>
 }
 
 export interface NDialogDescriptionProps extends DialogDescriptionProps, BaseExtensions {
-  una?: NDialogUnaProps['dialogDescription']
+  una?: Pick<NDialogUnaProps, 'dialogDescription'>
 }
 
 export interface NDialogContentProps extends DialogContentProps, BaseExtensions {
@@ -79,19 +79,19 @@ export interface NDialogContentProps extends DialogContentProps, BaseExtensions 
    *
    * @see https://github.com/una-ui/una-ui/blob/main/packages/preset/src/_shortcuts/dialog.ts
    */
-  una?: NDialogUnaProps['dialogContent']
+  una?: Pick<NDialogUnaProps, 'dialogContent'>
 }
 
 export interface NDialogOverlayProps extends BaseExtensions, Pick<NDialogProps, 'scrollable'> {
-  una?: NDialogUnaProps['dialogOverlay']
+  una?: Pick<NDialogUnaProps, 'dialogOverlay'>
 }
 
 export interface NDialogHeaderProps extends BaseExtensions {
-  una?: NDialogUnaProps['dialogHeader']
+  una?: Pick<NDialogUnaProps, 'dialogHeader'>
 }
 
 export interface NDialogFooterProps extends BaseExtensions {
-  una?: NDialogUnaProps['dialogFooter']
+  una?: Pick<NDialogUnaProps, 'dialogFooter'>
 }
 
 export interface NDialogCloseProps extends DialogCloseProps, NButtonProps {

--- a/packages/nuxt/src/runtime/types/dialog.ts
+++ b/packages/nuxt/src/runtime/types/dialog.ts
@@ -79,7 +79,7 @@ export interface NDialogContentProps extends DialogContentProps, BaseExtensions 
    *
    * @see https://github.com/una-ui/una-ui/blob/main/packages/preset/src/_shortcuts/dialog.ts
    */
-  una?: Pick<NDialogUnaProps, 'dialogContent'>
+  una?: Pick<NDialogUnaProps, 'dialogContent' | 'dialogOverlay'>
 }
 
 export interface NDialogOverlayProps extends BaseExtensions, Pick<NDialogProps, 'scrollable'> {

--- a/packages/nuxt/src/runtime/types/dropdown-menu.ts
+++ b/packages/nuxt/src/runtime/types/dropdown-menu.ts
@@ -69,7 +69,7 @@ export interface NDropdownMenuProps extends
  */
 export interface NDropdownMenuRootProps extends BaseExtensions, DropdownMenuRootProps {
   /** Additional properties for the una component */
-  una?: NDropdownMenuUnaProps['dropdownMenuRoot']
+  una?: Pick<NDropdownMenuUnaProps, 'dropdownMenuRoot'>
 }
 
 /**
@@ -77,7 +77,7 @@ export interface NDropdownMenuRootProps extends BaseExtensions, DropdownMenuRoot
  */
 export interface NDropdownMenuTriggerProps extends NButtonProps, DropdownMenuTriggerProps {
   /** Additional properties for the una component */
-  una?: NDropdownMenuUnaProps['dropdownMenuTrigger'] & NButtonProps['una']
+  una?: Pick<NDropdownMenuUnaProps, 'dropdownMenuTrigger'> & NButtonProps['una']
 }
 
 /**
@@ -96,7 +96,7 @@ export interface NDropdownMenuContentProps extends BaseExtensions, DropdownMenuC
   onPointerDownOutside?: (e: PointerDownOutsideEvent) => void
 
   /** Additional properties for the una component */
-  una?: NDropdownMenuUnaProps['dropdownMenuContent']
+  una?: Pick<NDropdownMenuUnaProps, 'dropdownMenuContent'>
 }
 
 /**
@@ -108,7 +108,7 @@ export interface NDropdownMenuLabelProps extends BaseExtensions, DropdownMenuLab
   /** Size of the label */
   size?: HTMLAttributes['class']
   /** Additional properties for the una component */
-  una?: NDropdownMenuUnaProps['dropdownMenuLabel']
+  una?: Pick<NDropdownMenuUnaProps, 'dropdownMenuLabel'>
 }
 
 /**
@@ -116,7 +116,7 @@ export interface NDropdownMenuLabelProps extends BaseExtensions, DropdownMenuLab
  */
 export interface NDropdownMenuSeparatorProps extends DropdownMenuSeparatorProps, NSeparatorProps {
   /** Additional properties for the una component */
-  una?: NDropdownMenuUnaProps['dropdownMenuSeparator'] & NSeparatorProps['una']
+  una?: Pick<NDropdownMenuUnaProps, 'dropdownMenuSeparator'> & NSeparatorProps['una']
 }
 
 /**
@@ -124,7 +124,7 @@ export interface NDropdownMenuSeparatorProps extends DropdownMenuSeparatorProps,
  */
 export interface NDropdownMenuGroupProps extends BaseExtensions, DropdownMenuGroupProps {
   /** Additional properties for the una component */
-  una?: NDropdownMenuUnaProps['dropdownMenuGroup']
+  una?: Pick<NDropdownMenuUnaProps, 'dropdownMenuGroup'>
 }
 
 /**
@@ -132,7 +132,7 @@ export interface NDropdownMenuGroupProps extends BaseExtensions, DropdownMenuGro
  */
 export interface NDropdownMenuSubContentProps extends BaseExtensions, DropdownMenuSubContentProps {
   /** Additional properties for the una component */
-  una?: NDropdownMenuUnaProps['dropdownMenuSubContent']
+  una?: Pick<NDropdownMenuUnaProps, 'dropdownMenuSubContent'>
 }
 
 /**
@@ -148,7 +148,7 @@ export interface NDropdownMenuItemProps extends DropdownMenuItemProps, NButtonPr
   /** Props for the dropdown menu shortcut */
   _dropdownMenuShortcut?: Partial<NDropdownMenuShortcutProps>
   /** Additional properties for the una component */
-  una?: NDropdownMenuUnaProps['dropdownMenuItem'] & NButtonProps['una']
+  una?: Pick<NDropdownMenuUnaProps, 'dropdownMenuItem'> & NButtonProps['una']
 
   /** Select event handler */
   onSelect?: (e: Event) => void
@@ -171,7 +171,7 @@ export interface NDropdownMenuShortcutProps extends BaseExtensions {
   /** Shortcut key for the item */
   value?: string
   /** Additional properties for the una component */
-  una?: NDropdownMenuUnaProps['dropdownMenuShortcut']
+  una?: Pick<NDropdownMenuUnaProps, 'dropdownMenuShortcut'>
 }
 
 /**

--- a/packages/nuxt/src/runtime/types/form.ts
+++ b/packages/nuxt/src/runtime/types/form.ts
@@ -71,23 +71,23 @@ export interface NFormFieldProps extends NLabelProps {
 export interface NFormMessageProps {
   class?: HTMLAttributes['class']
 
-  una?: NFormUnaProps['formMessage']
+  una?: Pick<NFormUnaProps, 'formMessage'>
 }
 
 export interface NFormLabelProps extends NLabelProps {
-  una?: NFormUnaProps['formLabel']
+  una?: Pick<NFormUnaProps, 'formLabel'>
 }
 
 export interface NFormItemProps {
   class?: HTMLAttributes['class']
 
-  una?: NFormUnaProps['formItem']
+  una?: Pick<NFormUnaProps, 'formItem'>
 }
 
 export interface NFormDescriptionProps {
   class?: HTMLAttributes['class']
 
-  una?: NFormUnaProps['formDescription']
+  una?: Pick<NFormUnaProps, 'formDescription'>
 }
 
 interface NFormUnaProps {

--- a/packages/nuxt/src/runtime/types/navigation-menu.ts
+++ b/packages/nuxt/src/runtime/types/navigation-menu.ts
@@ -71,7 +71,7 @@ export interface NNavigationMenuTriggerProps extends NavigationMenuTriggerProps,
 
 export interface NNavigationMenuContentProps extends NavigationMenuContentProps, BaseExtensions {
   /** Additional properties for the una component */
-  una?: NNavigationMenuUnaProps['navigationMenuContent']
+  una?: Pick<NNavigationMenuUnaProps, 'navigationMenuContent'>
 }
 
 export interface NNavigationMenuItemProps extends NavigationMenuItemProps, Omit<NNavigationMenuTriggerProps, 'una'>,
@@ -86,7 +86,7 @@ export interface NNavigationMenuItemProps extends NavigationMenuItemProps, Omit<
 
 export interface NNavigationMenuIndicatorProps extends NavigationMenuIndicatorProps, BaseExtensions {
   /** Additional properties for the una component */
-  una?: NNavigationMenuUnaProps['navigationMenuIndicator']
+  una?: Pick<NNavigationMenuUnaProps, 'navigationMenuIndicator'>
 }
 
 export interface NNavigationMenuLinkProps extends NavigationMenuLinkProps, Omit<NButtonProps, 'size'>, BaseExtensions {
@@ -102,19 +102,19 @@ export interface NNavigationMenuLinkProps extends NavigationMenuLinkProps, Omit<
   /** Event handler called when the link is clicked */
   onSelect?: (e: Event) => void
   /** Additional properties for the una component */
-  una?: NNavigationMenuUnaProps['navigationMenuLink'] & NButtonProps['una']
+  una?: Pick<NNavigationMenuUnaProps, 'navigationMenuLink'> & NButtonProps['una']
 }
 
 export interface NNavigationMenuListProps extends NavigationMenuListProps, Pick<NavigationMenuRootProps, 'orientation'>, BaseExtensions {
   /** Additional properties for the una component */
-  una?: NNavigationMenuUnaProps['navigationMenuList']
+  una?: Pick<NNavigationMenuUnaProps, 'navigationMenuList'>
 }
 
 export interface NNavigationMenuListItemProps extends NNavigationMenuLinkProps {
   /** Description of the link. This is only used when `orientation` is `horizontal`. */
   description?: string
   /** Additional properties for the una component */
-  una?: Pick<NNavigationMenuUnaProps, 'navigationMenuListItem' | 'navigationMenuContentItem' | 'navigationMenuContentItemWrapper' | 'navigationMenuContentItemLabel' | 'navigationMenuContentItemDescription'>
+  una?: NNavigationMenuLinkProps['una'] & Pick<NNavigationMenuUnaProps, 'navigationMenuListItem' | 'navigationMenuContentItem' | 'navigationMenuContentItemWrapper' | 'navigationMenuContentItemLabel' | 'navigationMenuContentItemDescription'>
 }
 
 export interface NNavigationMenuSubProps extends NavigationMenuSubProps {}

--- a/packages/nuxt/src/runtime/types/navigation-menu.ts
+++ b/packages/nuxt/src/runtime/types/navigation-menu.ts
@@ -86,7 +86,7 @@ export interface NNavigationMenuItemProps extends NavigationMenuItemProps, Omit<
 
 export interface NNavigationMenuIndicatorProps extends NavigationMenuIndicatorProps, BaseExtensions {
   /** Additional properties for the una component */
-  una?: Pick<NNavigationMenuUnaProps, 'navigationMenuIndicator'>
+  una?: Pick<NNavigationMenuUnaProps, 'navigationMenuIndicator' | 'navigationMenuIndicatorArrow'>
 }
 
 export interface NNavigationMenuLinkProps extends NavigationMenuLinkProps, Omit<NButtonProps, 'size'>, BaseExtensions {

--- a/packages/nuxt/src/runtime/types/scroll-area.ts
+++ b/packages/nuxt/src/runtime/types/scroll-area.ts
@@ -47,7 +47,7 @@ export interface NScrollAreaProps extends
 }
 
 export interface NScrollAreaRootProps extends ScrollAreaRootProps, BaseExtension {
-  una?: NScrollAreaUnaProps['scrollAreaRoot']
+  una?: Pick<NScrollAreaUnaProps, 'scrollAreaRoot'>
 }
 
 export interface NScrollAreaScrollbarProps extends ScrollAreaScrollbarProps, Pick<NScrollAreaProps, 'scrollArea'>, BaseExtension {
@@ -55,11 +55,11 @@ export interface NScrollAreaScrollbarProps extends ScrollAreaScrollbarProps, Pic
 }
 
 export interface NScrollAreaThumbProps extends ScrollAreaThumbProps, BaseExtension {
-  una?: NScrollAreaUnaProps['scrollAreaThumb']
+  una?: Pick<NScrollAreaUnaProps, 'scrollAreaThumb'>
 }
 
 export interface NScrollAreaViewportProps extends ScrollAreaViewportProps, Pick<BaseExtension, 'class'> {
-  una?: NScrollAreaUnaProps['scrollAreaViewport']
+  una?: Pick<NScrollAreaUnaProps, 'scrollAreaViewport'>
 }
 
 export interface NScrollAreaUnaProps {

--- a/packages/nuxt/src/runtime/types/tooltip.ts
+++ b/packages/nuxt/src/runtime/types/tooltip.ts
@@ -58,7 +58,7 @@ export interface NTooltipContentProps extends ContentExtensions {
    *
    * @see https://github.com/una-ui/una-ui/blob/main/packages/preset/src/_shortcuts/tooltip.ts
    */
-  una?: NTooltipUnaProps['tooltipContent']
+  una?: Pick<NTooltipUnaProps, 'tooltipContent'>
 }
 
 interface NTooltipUnaProps {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and standardized how the `una` property is passed to various UI components, ensuring consistent usage across dropdown menus, tooltips, forms, navigation menus, and scroll areas.
  - Refined type definitions for the `una` property, improving type safety and clarity for component props.
- **Style**
  - Improved template bindings for better maintainability and readability in multiple UI components.
  - Removed an invalid attribute binding from the dialog component for cleaner templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->