### PR TITLE
feat(Input): update default icon sizes and paddings preset

### DIFF
--- a/docs/components/content/examples/vue/input/ExampleVueInputEvents.vue
+++ b/docs/components/content/examples/vue/input/ExampleVueInputEvents.vue
@@ -10,7 +10,7 @@ const isPasswordVisible = ref(false)
   <div class="grid cols-1 gap-4 sm:cols-2">
     <NInput
       :type="isPasswordVisible ? 'text' : 'password'"
-      :trailing="isPasswordVisible ? 'i-heroicons-eye-20-solid' : 'i-heroicons-eye-slash-20-solid'"
+      :trailing="isPasswordVisible ? 'i-lucide-eye' : 'i-lucide-eye-off'"
       :una="{
         inputTrailing: 'pointer-events-auto cursor-pointer',
       }"
@@ -20,8 +20,8 @@ const isPasswordVisible = ref(false)
 
     <NInput
       input="outline-purple"
-      leading="i-heroicons-hand-thumb-up-20-solid"
-      trailing="i-heroicons-arrow-down-tray-20-solid "
+      leading="i-tabler-thumb-up-filled"
+      trailing="i-tabler-thumb-down-filled"
       :una="{
         inputLeading: 'active:scale-120 text-blue pointer-events-auto cursor-pointer active:text-green',
         inputTrailing: 'active:scale-90 text-yellow pointer-events-auto cursor-pointer active:text-lime',

--- a/docs/components/content/examples/vue/input/ExampleVueInputIcon.vue
+++ b/docs/components/content/examples/vue/input/ExampleVueInputIcon.vue
@@ -2,14 +2,14 @@
   <div class="grid cols-1 gap-4 sm:cols-2">
     <div class="sm:col-span-1">
       <NInput
-        leading="i-heroicons-magnifying-glass-20-solid"
+        leading="i-lucide-search"
         placeholder="This is leading icon"
       />
     </div>
 
     <div class="sm:col-span-1">
       <NInput
-        trailing="i-heroicons-question-mark-circle-20-solid text-primary"
+        trailing="i-tabler-help-circle-filled text-primary"
         placeholder="This is trailing icon with custom class"
       />
     </div>
@@ -18,8 +18,8 @@
       <NInput
         input="outline-purple"
         size="1.3rem"
-        leading="i-heroicons-paper-clip-20-solid"
-        trailing="i-heroicons-chat-bubble-left-ellipsis-20-solid"
+        leading="i-tabler-paperclip"
+        trailing="i-tabler-message-circle-filled"
         :una="{
           inputLeading: 'text-yellow',
           inputTrailing: 'text-blue',

--- a/docs/components/content/examples/vue/input/ExampleVueInputLeadingSlot.vue
+++ b/docs/components/content/examples/vue/input/ExampleVueInputLeadingSlot.vue
@@ -2,7 +2,7 @@
   <div class="flex">
     <NInput
       placeholder="Search"
-      trailing="i-heroicons-chat-bubble-left-right-20-solid"
+      trailing="i-tabler-message-chatbot-filled"
       class="pl-12"
     >
       <template #leading>

--- a/docs/components/content/examples/vue/input/ExampleVueInputLoading.vue
+++ b/docs/components/content/examples/vue/input/ExampleVueInputLoading.vue
@@ -28,7 +28,7 @@
     <NInput
       :una="{
         inputLoading: 'animate-pulse text-yellow',
-        inputLoadingIcon: 'i-heroicons-ellipsis-horizontal-20-solid',
+        inputLoadingIcon: 'i-tabler-brand-github-copilot',
       }"
       loading
       placeholder="This is possible too"

--- a/docs/components/content/examples/vue/input/ExampleVueInputTrailingSlot.vue
+++ b/docs/components/content/examples/vue/input/ExampleVueInputTrailingSlot.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex">
     <NInput
-      leading="i-heroicons-currency-dollar-20-solid"
+      leading="i-lucide-circle-dollar-sign"
       placeholder="Search"
       class="pr-12"
     >

--- a/docs/content/3.components/input.md
+++ b/docs/content/3.components/input.md
@@ -86,7 +86,7 @@ The **padding**, **icons**, and **text-size** of the input scale are dynamically
 ::
 :::
 
-### Leading and Trailing Icons
+### Icons
 
 | Prop       | Default | Type     | Description            |
 | ---------- | ------- | -------- | ---------------------- |

--- a/packages/preset/src/_shortcuts/input.ts
+++ b/packages/preset/src/_shortcuts/input.ts
@@ -8,8 +8,8 @@ export const staticInput: Record<`${InputPrefix}-${string}` | InputPrefix, strin
   'input-error-icon': 'i-error',
   'input-success-icon': 'i-success',
   'input-warning-icon': 'i-warning',
-  'input-leading-padding': 'pl-2.857142857142857em',
-  'input-trailing-padding': 'pr-2.857142857142857em',
+  'input-leading-padding': 'pl-2.5714285714285716em',
+  'input-trailing-padding': 'pr-2.5714285714285716em',
 
   // base
   'input': 'text-base text-0.875em leading-1.4285714285714286em px-0.8571428571428571em w-full focus-visible:outline-none input-disabled placeholder:text-muted block rounded-md shadow-sm bg-transparent transition-colors file:border-0  file:bg-transparent file:text-0.875em file:font-medium',
@@ -17,15 +17,15 @@ export const staticInput: Record<`${InputPrefix}-${string}` | InputPrefix, strin
   'input-textarea': 'min-h-4.285714285714286em py-0.5714285714em', // role='textarea'
   'input-disabled': 'disabled:(n-disabled)',
   'input-status-ring': 'ring-opacity-50 dark:ring-opacity-40',
-  'input-status-icon-base': 'size-1.25em',
-  'input-leading': 'size-1.25em',
-  'input-trailing': 'size-1.25em',
-  'input-loading': 'animate-spin size-1.25em',
+  'input-status-icon-base': 'square-1em',
+  'input-leading': 'square-1em',
+  'input-trailing': 'square-1em',
+  'input-loading': 'animate-spin square-1em',
 
   // wrappers
   'input-wrapper': 'relative flex items-center',
-  'input-leading-wrapper': 'pointer-events-none absolute inset-y-0 left-0 flex items-center pl-0.8571428571428571em text-muted',
-  'input-trailing-wrapper': 'pointer-events-none absolute inset-y-0 right-0 flex items-center pr-0.8571428571428571em text-muted',
+  'input-leading-wrapper': 'pointer-events-none absolute inset-y-0 start-0 flex items-center px-0.8571428571428571em text-muted',
+  'input-trailing-wrapper': 'pointer-events-none absolute inset-y-0 end-0 flex items-center px-0.8571428571428571em text-muted',
 
   // variants
   'input-outline-gray': 'border border-input focus-visible:ring-input focus-visible:ring-1',

--- a/packages/preset/src/_shortcuts/select.ts
+++ b/packages/preset/src/_shortcuts/select.ts
@@ -18,7 +18,7 @@ export const staticSelect: Record<`${SelectPrefix}-${string}` | SelectPrefix, st
   // components
   'select-trigger': 'px-0.8571428571428571em w-full [&>span]:truncate',
   'select-trigger-trailing-icon': 'i-lucide-chevron-down',
-  'select-trigger-trailing': 'size-1.4285714285714286em data-[status=error]:text-error data-[status=success]:text-success data-[status=warning]:text-warning data-[status=info]:text-info data-[status=default]:(n-disabled size-1.1428571428571428em)',
+  'select-trigger-trailing': 'size-1.1428571428571428em data-[status=error]:text-error data-[status=success]:text-success data-[status=warning]:text-warning data-[status=info]:text-info data-[status=default]:(n-disabled size-1.1428571428571428em) rtl:mr-auto ltr:ml-auto',
   'select-trigger-leading': 'size-1.1428571428571428em',
 
   'select-value': 'text-1em data-[status=error]:text-error-active data-[status=success]:text-success-active data-[status=warning]:text-warning-active data-[status=info]:text-info-active data-[placeholder]:n-disabled',


### PR DESCRIPTION
While working with #370 , I noticed that the leading and trailing icons in the `⁠Input` component are too large compared to shadcn-input. 

## Before:

<img width="386" alt="Screenshot 2025-05-01 at 11 15 18 PM" src="https://github.com/user-attachments/assets/fb533abb-9fe1-42eb-bbfe-5a1e8635ad64" />

<img width="782" alt="Screenshot 2025-05-01 at 11 14 36 PM" src="https://github.com/user-attachments/assets/274b68ea-9e67-409b-83ba-33d6171f578a" />

## After:

<img width="381" alt="Screenshot 2025-05-01 at 11 14 09 PM" src="https://github.com/user-attachments/assets/a44f59b7-c77e-468a-aa91-0b6a2fdd9594" />
<img width="783" alt="Screenshot 2025-05-01 at 11 14 21 PM" src="https://github.com/user-attachments/assets/28e6f565-8c6b-4729-a9f3-42b77f1f67a9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Adjusted padding, sizing, and positioning for input components to improve consistency and alignment.
  - Updated select component icon sizing and added support for correct margin alignment in both left-to-right and right-to-left layouts.
  - Replaced multiple input component icons with new icon sets for a refreshed visual appearance.
  - Simplified input icons section heading for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->