### PR TITLE
fix(extractor): support double quotes

### DIFF
--- a/packages/extractor-vue-script/src/index.test.ts
+++ b/packages/extractor-vue-script/src/index.test.ts
@@ -32,7 +32,7 @@ const props = defineProps({
   expect(result).toStrictEqual(['[size~=\"md\"]'])
 })
 
-it.todo('test extractor quote agnostic', async () => {
+it('test extractor double quotes', async () => {
   const code = `
 defineProps({
     size: {type: String, default: "md"}

--- a/packages/extractor-vue-script/src/index.ts
+++ b/packages/extractor-vue-script/src/index.ts
@@ -25,7 +25,7 @@ function splitCodeWithArbitraryVariants(code: string, prefixes: string[]): strin
   prefixes = [...new Set([...prefixes, ...camelCasePrefixes])]
 
   for (const prefix of prefixes) {
-    const regex = new RegExp(`\\b${prefix}\\s*:\\s*(?:'([^']*)'|{[^}]*\\bdefault\\s*:\\s*'([^']*)'\\s*,?.*?})`, 'gms')
+    const regex = new RegExp(`\\b${prefix}\\s*:\\s*(?:['"]([^'"]*)['"]|{[^}]*\\bdefault\\s*:\\s*['"]([^'"]*)['"]\\s*,?.*?})`, 'gms')
     let match: RegExpExecArray | null
 
     while (true) {


### PR DESCRIPTION
caveat, quotes containing quotes will probably break

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for extracting attribute selectors from Vue script code that uses either single or double quotes around property values. Selectors like [size~="md"] are now correctly generated regardless of quote style.

- **Tests**
  - Added a test to verify correct extraction when double quotes are used in property values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->