### PR TITLE
fix(Nuxt): use reactiveOmit instead of computed to delegate props

### DIFF
--- a/packages/nuxt/src/runtime/components/combobox/ComboboxAnchor.vue
+++ b/packages/nuxt/src/runtime/components/combobox/ComboboxAnchor.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NComboboxAnchorProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ComboboxAnchor, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../utils'
 
 const props = defineProps<NComboboxAnchorProps>()
 
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwarded = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/combobox/ComboboxEmpty.vue
+++ b/packages/nuxt/src/runtime/components/combobox/ComboboxEmpty.vue
@@ -1,18 +1,14 @@
 <script setup lang="ts">
 import type { NComboboxEmptyProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ComboboxEmpty } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = withDefaults(defineProps<NComboboxEmptyProps>(), {
   size: 'sm',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/combobox/ComboboxGroup.vue
+++ b/packages/nuxt/src/runtime/components/combobox/ComboboxGroup.vue
@@ -4,18 +4,14 @@ import type { AcceptableValue } from 'reka-ui'
 
 <script setup lang="ts" generic="T extends AcceptableValue">
 import type { NComboboxGroupProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ComboboxGroup } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../utils'
+
 import ComboboxLabel from './ComboboxLabel.vue'
 
 const props = defineProps<NComboboxGroupProps<T>>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/combobox/ComboboxItem.vue
+++ b/packages/nuxt/src/runtime/components/combobox/ComboboxItem.vue
@@ -1,20 +1,16 @@
 <script setup lang="ts" generic="T">
 import type { ComboboxItemEmits } from 'reka-ui'
 import type { NComboboxItemProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ComboboxItem, useForwardPropsEmits } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = withDefaults(defineProps<NComboboxItemProps<T>>(), {
   size: 'sm',
 })
 const emits = defineEmits<ComboboxItemEmits>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>

--- a/packages/nuxt/src/runtime/components/combobox/ComboboxItemIndicator.vue
+++ b/packages/nuxt/src/runtime/components/combobox/ComboboxItemIndicator.vue
@@ -1,18 +1,14 @@
 <script setup lang="ts">
 import type { NComboboxItemIndicatorProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ComboboxItemIndicator, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = withDefaults(defineProps<NComboboxItemIndicatorProps>(), {
   icon: 'combobox-item-indicator-icon-name',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwarded = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/combobox/ComboboxSeparator.vue
+++ b/packages/nuxt/src/runtime/components/combobox/ComboboxSeparator.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NComboboxSeparatorProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ComboboxSeparator } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = defineProps<NComboboxSeparatorProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/combobox/ComboboxViewport.vue
+++ b/packages/nuxt/src/runtime/components/combobox/ComboboxViewport.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NComboboxViewportProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ComboboxViewport, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = defineProps<NComboboxViewportProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwarded = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/data/table/TableEmpty.vue
+++ b/packages/nuxt/src/runtime/components/data/table/TableEmpty.vue
@@ -1,19 +1,15 @@
 <script setup lang="ts">
 import type { NTableEmptyProps } from '../../../types'
-import { computed } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
 import { cn, omitProps } from '../../../utils'
 import TableCell from './TableCell.vue'
+
 import TableRow from './TableRow.vue'
 
 const props = withDefaults(defineProps<NTableEmptyProps>(), {
   colspan: 1,
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/data/table/TableLoading.vue
+++ b/packages/nuxt/src/runtime/components/data/table/TableLoading.vue
@@ -1,19 +1,15 @@
 <script setup lang="ts">
 import type { NTableLoadingProps } from '../../../types'
-import { computed } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
 import { cn } from '../../../utils'
 import Progress from '../../elements/Progress.vue'
+
 import TableRow from './TableRow.vue'
 
 const props = withDefaults(defineProps<NTableLoadingProps>(), {
   size: '2.5px',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/drawer/DrawerDescription.vue
+++ b/packages/nuxt/src/runtime/components/drawer/DrawerDescription.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NDrawerDescriptionProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { DrawerDescription } from 'vaul-vue'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = defineProps<NDrawerDescriptionProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/drawer/DrawerOverlay.vue
+++ b/packages/nuxt/src/runtime/components/drawer/DrawerOverlay.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NDrawerOverlayProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { DrawerOverlay } from 'vaul-vue'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = defineProps<NDrawerOverlayProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/drawer/DrawerTitle.vue
+++ b/packages/nuxt/src/runtime/components/drawer/DrawerTitle.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NDrawerTitleProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { DrawerTitle } from 'vaul-vue'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = defineProps<NDrawerTitleProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/elements/Progress.vue
+++ b/packages/nuxt/src/runtime/components/elements/Progress.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import type { NProgressProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import {
   ProgressIndicator,
   ProgressRoot,
 } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = withDefaults(
@@ -14,12 +15,7 @@ const props = withDefaults(
     rounded: 'full',
   },
 )
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/elements/Separator.vue
+++ b/packages/nuxt/src/runtime/components/elements/Separator.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
 import type { NSeparatorProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { Separator } from 'reka-ui'
-import { cn, omitProps } from '../../utils'
+import { cn } from '../../utils'
 
 const props = withDefaults(defineProps<NSeparatorProps>(), {
   orientation: 'horizontal',
 })
 
-const delegatedProps = reactiveOmit(props, ['una'])
+const delegatedProps = reactiveOmit(props, ['una', 'separatorPosition'])
 </script>
 
 <template>
   <Separator
-    v-bind="omitProps(delegatedProps, ['una', 'separatorPosition'])"
+    v-bind="delegatedProps"
     :class="
       cn(
         'separator',

--- a/packages/nuxt/src/runtime/components/elements/Separator.vue
+++ b/packages/nuxt/src/runtime/components/elements/Separator.vue
@@ -1,18 +1,13 @@
 <script setup lang="ts">
 import type { NSeparatorProps } from '../../types'
 import { Separator } from 'reka-ui'
-import { computed } from 'vue'
 import { cn, omitProps } from '../../utils'
 
 const props = withDefaults(defineProps<NSeparatorProps>(), {
   orientation: 'horizontal',
 })
 
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = omitProps(props, ['una'])
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['una'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/elements/Toggle.vue
+++ b/packages/nuxt/src/runtime/components/elements/Toggle.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import type { ToggleEmits } from 'reka-ui'
 import type { NToggleProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { Toggle, useForwardPropsEmits } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../utils'
+
 import Button from './Button.vue'
 
 const props = withDefaults(defineProps<NToggleProps>(), {
@@ -14,12 +15,7 @@ const props = withDefaults(defineProps<NToggleProps>(), {
 })
 
 const emits = defineEmits<ToggleEmits>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/card/Card.vue
+++ b/packages/nuxt/src/runtime/components/elements/card/Card.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import type { NCardProps } from '../../../types/card'
-import { computed } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
 import { cn } from '../../../utils'
 import CardContent from './CardContent.vue'
 import CardDescription from './CardDescription.vue'
 import CardFooter from './CardFooter.vue'
 import CardHeader from './CardHeader.vue'
+
 import CardTitle from './CardTitle.vue'
 
 defineOptions({
@@ -15,12 +16,7 @@ defineOptions({
 const props = withDefaults(defineProps<NCardProps>(), {
   card: 'outline-gray',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuContent.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuContent.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import type { DropdownMenuContentEmits } from 'reka-ui'
 import type { NDropdownMenuContentProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import {
   DropdownMenuContent,
   DropdownMenuPortal,
   useForwardPropsEmits,
 } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
 
 const props = withDefaults(
@@ -17,11 +17,7 @@ const props = withDefaults(
 )
 const emits = defineEmits<DropdownMenuContentEmits>()
 
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuItem.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuItem.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import type { NDropdownMenuItemProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { DropdownMenuItem, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
 import Button from '../Button.vue'
+
 import DropdownMenuShortcut from './DropdownMenuShortcut.vue'
 
 defineOptions({
@@ -17,12 +18,7 @@ const props = withDefaults(defineProps<NDropdownMenuItemProps>(), {
 })
 
 const slots = defineSlots<any>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuLabel.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuLabel.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NDropdownMenuLabelProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { DropdownMenuLabel, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../../utils'
 
 const props = defineProps<NDropdownMenuLabelProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuSeparator.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuSeparator.vue
@@ -1,19 +1,15 @@
 <script setup lang="ts">
 import type { NDropdownMenuSeparatorProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import {
   DropdownMenuSeparator,
 } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
+
 import Separator from '../Separator.vue'
 
 const props = defineProps<NDropdownMenuSeparatorProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuSubContent.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuSubContent.vue
@@ -1,21 +1,17 @@
 <script setup lang="ts">
 import type { DropdownMenuSubContentEmits } from 'reka-ui'
 import type { NDropdownMenuSubContentProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import {
   DropdownMenuSubContent,
   useForwardPropsEmits,
 } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../../utils'
 
 const props = defineProps<NDropdownMenuSubContentProps>()
 const emits = defineEmits<DropdownMenuSubContentEmits>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuSubTrigger.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuSubTrigger.vue
@@ -1,23 +1,19 @@
 <script setup lang="ts">
 import type { NDropdownMenuSubTriggerProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import {
   DropdownMenuSubTrigger,
   useForwardProps,
 } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
+
 import Button from '../Button.vue'
 
 const props = withDefaults(defineProps<NDropdownMenuSubTriggerProps>(), {
   dropdownMenuItem: '~',
   rounded: 'sm',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/pagination/PaginationEllipsis.vue
+++ b/packages/nuxt/src/runtime/components/elements/pagination/PaginationEllipsis.vue
@@ -1,19 +1,15 @@
 <script setup lang="ts">
 import type { NPaginationEllipsisProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { PaginationEllipsis, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
+
 import Icon from '../../elements/Icon.vue'
 
 const props = withDefaults(defineProps<NPaginationEllipsisProps>(), {
   paginationEllipsis: '~',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/pagination/PaginationFirst.vue
+++ b/packages/nuxt/src/runtime/components/elements/pagination/PaginationFirst.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { NPaginationFirstProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { PaginationFirst, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
+
 import Button from '../../elements/Button.vue'
 
 const props = withDefaults(defineProps<NPaginationFirstProps>(), {
@@ -11,12 +12,7 @@ const props = withDefaults(defineProps<NPaginationFirstProps>(), {
   icon: true,
   label: 'pagination-first-icon',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/pagination/PaginationLast.vue
+++ b/packages/nuxt/src/runtime/components/elements/pagination/PaginationLast.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { NPaginationLastProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { PaginationLast, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
+
 import Button from '../../elements/Button.vue'
 
 const props = withDefaults(defineProps<NPaginationLastProps>(), {
@@ -11,12 +12,7 @@ const props = withDefaults(defineProps<NPaginationLastProps>(), {
   square: true,
   label: 'pagination-last-icon',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/pagination/PaginationListItem.vue
+++ b/packages/nuxt/src/runtime/components/elements/pagination/PaginationListItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { NPaginationListItemProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { PaginationListItem, useForwardProps } from 'reka-ui'
 import { computed } from 'vue'
 import { cn } from '../../../utils'
@@ -11,11 +12,7 @@ const props = withDefaults(defineProps<NPaginationListItemProps>(), {
   square: true,
 })
 
-const delegatedProps = computed(() => {
-  const { value: __, class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['value'])
 
 const label = computed(() => {
   return props.label || props.value.toString()

--- a/packages/nuxt/src/runtime/components/elements/pagination/PaginationNext.vue
+++ b/packages/nuxt/src/runtime/components/elements/pagination/PaginationNext.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { NPaginationNextProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { PaginationNext, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
+
 import Button from '../../elements/Button.vue'
 
 const props = withDefaults(defineProps<NPaginationNextProps>(), {
@@ -11,12 +12,7 @@ const props = withDefaults(defineProps<NPaginationNextProps>(), {
   icon: true,
   label: 'pagination-next-icon',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/pagination/PaginationPrev.vue
+++ b/packages/nuxt/src/runtime/components/elements/pagination/PaginationPrev.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { NPaginationPrevProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { PaginationPrev, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
+
 import Button from '../../elements/Button.vue'
 
 const props = withDefaults(defineProps<NPaginationPrevProps>(), {
@@ -11,12 +12,7 @@ const props = withDefaults(defineProps<NPaginationPrevProps>(), {
   icon: true,
   label: 'pagination-prev-icon',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/popover/Popover.vue
+++ b/packages/nuxt/src/runtime/components/elements/popover/Popover.vue
@@ -1,18 +1,14 @@
 <script setup lang="ts">
 import type { PopoverRootEmits } from 'reka-ui'
 import type { NPopoverProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { PopoverRoot, PopoverTrigger, useForwardPropsEmits } from 'reka-ui'
-import { computed } from 'vue'
 import NPopoverContent from './PopoverContent.vue'
 
 const props = defineProps<NPopoverProps>()
 const emits = defineEmits<PopoverRootEmits>()
 
-const delegatedProps = computed(() => {
-  const { _popoverContent, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['_popoverContent'])
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/popover/PopoverContent.vue
+++ b/packages/nuxt/src/runtime/components/elements/popover/PopoverContent.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import type { PopoverContentEmits } from 'reka-ui'
 import type { NPopoverContentProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import {
   PopoverContent,
   PopoverPortal,
   useForwardPropsEmits,
 } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
 
 defineOptions({
@@ -22,11 +22,7 @@ const props = withDefaults(
 )
 const emits = defineEmits<PopoverContentEmits>()
 
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/tooltip/TooltipContent.vue
+++ b/packages/nuxt/src/runtime/components/elements/tooltip/TooltipContent.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { TooltipContentEmits } from 'reka-ui'
 import type { NTooltipContentProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { TooltipContent, TooltipPortal, useForwardPropsEmits } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
 
 defineOptions({
@@ -16,11 +16,7 @@ const props = withDefaults(defineProps<NTooltipContentProps>(), {
 
 const emits = defineEmits<TooltipContentEmits>()
 
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>

--- a/packages/nuxt/src/runtime/components/forms/select/SelectContent.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectContent.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
 import type { SelectContentEmits } from 'reka-ui'
 import type { NSelectContentProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import {
   SelectContent,
   SelectPortal,
   SelectViewport,
   useForwardPropsEmits,
 } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
 import SelectScrollDownButton from './SelectScrollDownButton.vue'
+
 import SelectScrollUpButton from './SelectScrollUpButton.vue'
 
 defineOptions({
@@ -23,12 +24,7 @@ const props = withDefaults(
   },
 )
 const emits = defineEmits<SelectContentEmits>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 </script>

--- a/packages/nuxt/src/runtime/components/forms/select/SelectGroup.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectGroup.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NSelectGroupProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { SelectGroup } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../../utils'
 
 const props = defineProps<NSelectGroupProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/forms/select/SelectItem.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectItem.vue
@@ -1,23 +1,19 @@
 <script setup lang="ts">
 import type { NSelectItemProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import {
   SelectItem,
   useForwardProps,
 } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
 import SelectItemIndicator from './SelectItemIndicator.vue'
+
 import SelectItemText from './SelectItemText.vue'
 
 const props = withDefaults(defineProps<NSelectItemProps>(), {
   selectItem: 'gray',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/forms/select/SelectScrollDownButton.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectScrollDownButton.vue
@@ -1,17 +1,13 @@
 <script setup lang="ts">
 import type { NSelectScrollDownButtonProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { SelectScrollDownButton, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
+
 import Icon from '../../elements/Icon.vue'
 
 const props = defineProps<NSelectScrollDownButtonProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/forms/select/SelectScrollUpButton.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectScrollUpButton.vue
@@ -1,17 +1,13 @@
 <script setup lang="ts">
 import type { NSelectScrollUpButtonProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { SelectScrollUpButton, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
 import { cn } from '../../../utils'
+
 import Icon from '../../elements/Icon.vue'
 
 const props = defineProps<NSelectScrollUpButtonProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/forms/select/SelectSeparator.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectSeparator.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NSelectSeparator } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { SelectSeparator } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../../utils'
 
 const props = defineProps<NSelectSeparator>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuList.vue
+++ b/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuList.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NNavigationMenuListProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { NavigationMenuList, useForwardProps } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = defineProps<NNavigationMenuListProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 
 const forwardedProps = useForwardProps(delegatedProps)
 </script>

--- a/packages/nuxt/src/runtime/components/overlays/toast/ToastAction.vue
+++ b/packages/nuxt/src/runtime/components/overlays/toast/ToastAction.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { NToastActionProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ToastAction } from 'reka-ui'
-import { computed } from 'vue'
 import { cn, omitProps, randomId } from '../../../utils'
+
 import Button from '../../elements/Button.vue'
 
 defineOptions({
@@ -13,12 +14,7 @@ const props = withDefaults(defineProps<NToastActionProps>(), {
   btn: 'solid-white',
   size: 'xs',
 })
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/overlays/toast/ToastDescription.vue
+++ b/packages/nuxt/src/runtime/components/overlays/toast/ToastDescription.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NToastDescriptionProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ToastDescription } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../../utils'
 
 const props = defineProps<NToastDescriptionProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/overlays/toast/ToastTitle.vue
+++ b/packages/nuxt/src/runtime/components/overlays/toast/ToastTitle.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NToastTitleProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ToastTitle } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../../utils'
 
 const props = defineProps<NToastTitleProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/overlays/toast/ToastViewport.vue
+++ b/packages/nuxt/src/runtime/components/overlays/toast/ToastViewport.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NToastViewportProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { ToastViewport } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../../utils'
 
 const props = defineProps<NToastViewportProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/sheet/SheetDescription.vue
+++ b/packages/nuxt/src/runtime/components/sheet/SheetDescription.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NSheetDescriptionProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { DialogDescription } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = defineProps<NSheetDescriptionProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/sheet/SheetTitle.vue
+++ b/packages/nuxt/src/runtime/components/sheet/SheetTitle.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { NSheetTitleProps } from '../../types'
+import { reactiveOmit } from '@vueuse/core'
 import { DialogTitle } from 'reka-ui'
-import { computed } from 'vue'
+
 import { cn } from '../../utils'
 
 const props = defineProps<NSheetTitleProps>()
-
-const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
-
-  return delegated
-})
+const delegatedProps = reactiveOmit(props, ['class'])
 </script>
 
 <template>


### PR DESCRIPTION
This PR will resolve reactivity warning such below:
  
<img width="661" alt="Screenshot 2025-05-28 at 2 51 24 AM" src="https://github.com/user-attachments/assets/b2dc7d4a-48a6-4a53-a66c-e1b060763296" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal logic across multiple components by using a utility to more efficiently omit specific properties from component props.
  - Improved maintainability and consistency in how certain properties are handled within components.
- **Chores**
  - Streamlined code by removing unnecessary imports and reducing manual property handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->