### PR TITLE
feat(AlertDialog)!: rename `preventClose` prop to `dismissible`

### DIFF
--- a/docs/components/content/examples/vue/alert-dialog/ExampleVueAlertDialogPreventClose.vue
+++ b/docs/components/content/examples/vue/alert-dialog/ExampleVueAlertDialogPreventClose.vue
@@ -2,7 +2,7 @@
   <NAlertDialog
     title="Prevent Close Alert Dialog"
     description="This is alert dialog prevents closing using escape key."
-    prevent-close
+    dismissible
   >
     <template #trigger>
       <NButton btn="outline-gray">

--- a/docs/content/3.components/alert-dialog.md
+++ b/docs/content/3.components/alert-dialog.md
@@ -59,9 +59,9 @@ The `AlertDialogActionProps` and `AlertDialogCancelProps` extends the `NButton` 
 
 ### Prevent Closing
 
-| Prop           | Default | Type      | Description                                                |
-| -------------- | ------- | --------- | ---------------------------------------------------------- |
-| `preventClose` | -       | `boolean` | If true, the alert dialog will not close escape key press. |
+| Prop          | Default | Type      | Description                                                      |
+| ------------- | ------- | --------- | ---------------------------------------------------------------- |
+| `dismissible` | `true`  | `boolean` | If `false`, the alert dialog will not close on escape key press. |
 
 :::CodeGroup
 ::div{label="Preview" preview}

--- a/packages/nuxt/src/runtime/components/alert-dialog/AlertDialog.vue
+++ b/packages/nuxt/src/runtime/components/alert-dialog/AlertDialog.vue
@@ -20,6 +20,7 @@ defineOptions({
 
 const props = withDefaults(defineProps<NAlertDialogProps>(), {
   overlay: true,
+  dismissible: true,
 })
 const emits = defineEmits<AlertDialogEmits & {
   cancel: [Event]
@@ -56,7 +57,7 @@ const forwarded = useForwardPropsEmits(rootProps, emits)
       <AlertDialogContent
         v-bind="_alertDialogContent"
         :_alert-dialog-overlay
-        :prevent-close
+        :dismissible
         :una
       >
         <VisuallyHidden v-if="(title === DEFAULT_TITLE || !!$slots.title) || (description === DEFAULT_DESCRIPTION || !!$slots.description)">

--- a/packages/nuxt/src/runtime/components/alert-dialog/AlertDialogContent.vue
+++ b/packages/nuxt/src/runtime/components/alert-dialog/AlertDialogContent.vue
@@ -17,12 +17,13 @@ defineOptions({
 
 const props = withDefaults(defineProps<NAlertDialogContentProps>(), {
   overlay: true,
+  dismissible: true,
 })
 const emits = defineEmits<AlertDialogContentEmits>()
 const delegatedProps = reactiveOmit(props, ['class', 'una', '_alertDialogOverlay'])
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 const contentEvents = computed(() => {
-  if (props.preventClose) {
+  if (!props.dismissible) {
     return {
       pointerDownOutside: (e: Event) => e.preventDefault(),
       interactOutside: (e: Event) => e.preventDefault(),

--- a/packages/nuxt/src/runtime/types/alert-dialog.ts
+++ b/packages/nuxt/src/runtime/types/alert-dialog.ts
@@ -12,7 +12,7 @@ import type {
 import type { HTMLAttributes } from 'vue'
 import type { NButtonProps } from './button'
 
-export interface NAlertDialogProps extends AlertDialogProps, Pick<NAlertDialogContentProps, 'preventClose' | 'overlay' | '_alertDialogCancel' | '_alertDialogAction' | '_alertDialogOverlay'> {
+export interface NAlertDialogProps extends AlertDialogProps, Pick<NAlertDialogContentProps, 'dismissible' | 'overlay' | '_alertDialogCancel' | '_alertDialogAction' | '_alertDialogOverlay'> {
   /**
    * The title of the dialog.
    */
@@ -57,7 +57,7 @@ export interface NAlertDialogContentProps extends AlertDialogContentProps, BaseE
    *
    * @default true
    */
-  preventClose?: boolean
+  dismissible?: boolean
   /**
    * Show overlay.
    *


### PR DESCRIPTION
## ⚠️ Breaking Changes

- `prevent-close` renamed to `dismissible`; `true` by default