### PR TITLE
feat(ExtractorVueScript): add support for ternary patterns

### DIFF
--- a/packages/extractor-vue-script/src/index.test.ts
+++ b/packages/extractor-vue-script/src/index.test.ts
@@ -3,6 +3,8 @@ import extractorVueScript from './index'
 
 const prefixes = [
   'size',
+  'badge',
+  'btn',
 ]
 
 const extractor = extractorVueScript({ prefixes })
@@ -19,7 +21,7 @@ const props = withDefaults(defineProps<{size?: string}>(), {
 })
 `
   const result = await extract(code)
-  expect(result).toStrictEqual(['[size~=\"md\"]'])
+  expect(result).toStrictEqual(['[size~="md"]'])
 })
 
 it('test extractor vue object prop default', async () => {
@@ -29,7 +31,7 @@ const props = defineProps({
 })
 `
   const result = await extract(code)
-  expect(result).toStrictEqual(['[size~=\"md\"]'])
+  expect(result).toStrictEqual(['[size~="md"]'])
 })
 
 it('test extractor double quotes', async () => {
@@ -39,7 +41,125 @@ defineProps({
 })
 `
   const result = await extract(code)
-  expect(result).toStrictEqual(['[size~=\"md\"]'])
+  expect(result).toStrictEqual(['[size~="md"]'])
+})
+
+// New tests for conditional statements
+it('test extractor simple ternary operator', async () => {
+  const code = `
+const badges = [
+  {
+    badge: status.value === 'success' ? 'solid-violet' : 'outline-primary',
+  }
+]
+`
+  const result = await extract(code)
+  expect(result).toContain('[badge~="solid-violet"]')
+  expect(result).toContain('[badge~="outline-primary"]')
+})
+
+it('test extractor ternary with kebab-case prefix', async () => {
+  const code = `
+const config = {
+  btn: isActive ? 'solid-blue' : 'ghost-gray'
+}
+`
+  const result = await extract(code)
+  expect(result).toContain('[btn~="solid-blue"]')
+  expect(result).toContain('[btn~="ghost-gray"]')
+})
+
+it('test extractor ternary with template literals', async () => {
+  const code = `
+const config = {
+  badge: condition ? \`solid-green\` : \`outline-red\`
+}
+`
+  const result = await extract(code)
+  expect(result).toContain('[badge~="solid-green"]')
+  expect(result).toContain('[badge~="outline-red"]')
+})
+
+it('test extractor ternary with multiple spaces', async () => {
+  const code = `
+const config = {
+  size  :   isLarge   ?   'lg'   :   'sm'  
+}
+`
+  const result = await extract(code)
+  expect(result).toContain('[size~="lg"]')
+  expect(result).toContain('[size~="sm"]')
+})
+
+it('test extractor ternary with complex condition', async () => {
+  const code = `
+const config = {
+  badge: status.value === 'info' && isActive ? 'solid-blue' : 'outline-primary'
+}
+`
+  const result = await extract(code)
+  expect(result).toContain('[badge~="solid-blue"]')
+  expect(result).toContain('[badge~="outline-primary"]')
+})
+
+it('test extractor multiple ternaries', async () => {
+  const code = `
+const badges = [
+  {
+    badge: status === 'success' ? 'solid-green' : 'outline-gray',
+    size: isLarge ? 'lg' : 'sm'
+  }
+]
+`
+  const result = await extract(code)
+  expect(result).toContain('[badge~="solid-green"]')
+  expect(result).toContain('[badge~="outline-gray"]')
+  expect(result).toContain('[size~="lg"]')
+  expect(result).toContain('[size~="sm"]')
+})
+
+it('test extractor ternary with compound classes', async () => {
+  const code = `
+const config = {
+  btn: isPrimary ? 'solid-blue hover:solid-blue-600' : 'outline-gray hover:outline-gray-600'
+}
+`
+  const result = await extract(code)
+  expect(result).toContain('[btn~="solid-blue"]')
+  expect(result).toContain('[btn~="hover:solid-blue-600"]')
+  expect(result).toContain('[btn~="outline-gray"]')
+  expect(result).toContain('[btn~="hover:outline-gray-600"]')
+})
+
+it('test extractor mixed regular and conditional', async () => {
+  const code = `
+const props = withDefaults(defineProps<{size?: string}>(), {
+    size: 'md'
+})
+
+const config = {
+  badge: isActive ? 'solid-blue' : 'outline-primary'
+}
+`
+  const result = await extract(code)
+  expect(result).toContain('[size~="md"]')
+  expect(result).toContain('[badge~="solid-blue"]')
+  expect(result).toContain('[badge~="outline-primary"]')
+})
+
+it('test extractor deduplicates results', async () => {
+  const code = `
+const config = {
+  badge: first ? 'solid-blue' : 'outline-primary',
+  size: second ? 'solid-blue' : 'lg'
+}
+`
+  const result = await extract(code)
+  const solidBlueCount = result.filter(r => r === '[badge~="solid-blue"]' || r === '[size~="solid-blue"]').length
+  expect(solidBlueCount).toBe(2) // Should have both [badge~="solid-blue"] and [size~="solid-blue"]
+
+  // Check no duplicates in the final result
+  expect(result.length).toBe(new Set(result).size)
 })
 
 it.todo('test extractor prop destructure', async () => {
@@ -47,5 +167,5 @@ it.todo('test extractor prop destructure', async () => {
 const {size = "md"} = defineProps<{size?: string}>()
 `
   const result = await extract(code)
-  expect(result).toStrictEqual(['[size~=\"md\"]'])
+  expect(result).toStrictEqual(['[size~="md"]'])
 })

--- a/packages/extractor-vue-script/src/index.ts
+++ b/packages/extractor-vue-script/src/index.ts
@@ -18,23 +18,53 @@ function generateSelectors(prefix: string, values: string[]): string[] {
     .map(v => `[${prefix}~="${v}"]`)
 }
 
+function normalizePrefixes(prefixes: string[]): string[] {
+  const camelCasePrefixes = prefixes.map(prefix => prefix.replace(/-([a-z])/g, (_, c) => c.toUpperCase()))
+  return [...new Set([...prefixes, ...camelCasePrefixes])]
+}
+
 function splitCodeWithArbitraryVariants(code: string, prefixes: string[]): string[] {
   const result: string[] = []
-  const camelCasePrefixes = prefixes.map(prefix => prefix.replace(/-([a-z])/g, (_, c) => c.toUpperCase()))
+  const normalizedPrefixes = normalizePrefixes(prefixes)
 
-  prefixes = [...new Set([...prefixes, ...camelCasePrefixes])]
-
-  for (const prefix of prefixes) {
+  for (const prefix of normalizedPrefixes) {
     const regex = new RegExp(`\\b${prefix}\\s*:\\s*(?:['"]([^'"]*)['"]|{[^}]*\\bdefault\\s*:\\s*['"]([^'"]*)['"]\\s*,?.*?})`, 'gms')
     let match: RegExpExecArray | null
 
-    while (true) {
-      match = regex.exec(code)
-      if (match === null)
-        break
+    // eslint-disable-next-line no-cond-assign
+    while ((match = regex.exec(code)) !== null) {
       const values = (match[1] ?? match[2]).split(defaultSplitRE)
       const selectors = generateSelectors(prefix, values)
+      result.push(...selectors)
+    }
+  }
 
+  return result
+}
+
+function extractConditionalStatements(code: string, prefixes: string[]): string[] {
+  const result: string[] = []
+  const normalizedPrefixes = normalizePrefixes(prefixes)
+
+  for (const prefix of normalizedPrefixes) {
+    // Match ternary operators: prefix: condition ? 'value1' : 'value2'
+    // Also handles template literals and computed properties
+    const ternaryRegex = new RegExp(
+      `\\b${prefix}\\s*:\\s*[^?]*?\\?\\s*['"\`]([^'"\`]*?)['"\`]\\s*:\\s*['"\`]([^'"\`]*?)['"\`]`,
+      'gms',
+    )
+    let match: RegExpExecArray | null
+
+    // eslint-disable-next-line no-cond-assign
+    while ((match = ternaryRegex.exec(code)) !== null) {
+      const [, trueValue, falseValue] = match
+
+      const allValues = [
+        ...trueValue.split(defaultSplitRE),
+        ...falseValue.split(defaultSplitRE),
+      ]
+
+      const selectors = generateSelectors(prefix, allValues)
       result.push(...selectors)
     }
   }
@@ -47,7 +77,12 @@ function extractorVueScript(options?: ExtractorVueScriptOptions): Extractor {
     name: '@una-ui/extractor-vue-script',
     order: 0,
     async extract({ code }) {
-      return splitCodeWithArbitraryVariants(code, options?.prefixes ?? [])
+      const prefixes = options?.prefixes ?? []
+
+      const regularResults = splitCodeWithArbitraryVariants(code, prefixes)
+      const conditionalResults = extractConditionalStatements(code, prefixes)
+
+      return [...new Set([...regularResults, ...conditionalResults])]
     },
   }
 }


### PR DESCRIPTION
This PR enhances the script parser to support ternary condition detection directly within object literals.

#### 🧩 Problem

Previously, ternary expressions inside object properties were not detected correctly. For example, the following syntax was not supported:

```ts
const badges = [
  {
    badge: status.value === 'success' ? 'solid-violet' : 'outline-primary',
  }
];
```

As a workaround, we were forced to write verbose alternatives such as:

```ts
const badges = [
  {
    ...(status.value === 'success'
      ? { badge: 'solid-violet' }
      : { badge: 'outline-primary' }),
  }
];
```

#### ✅ Solution

This PR improves the detection logic to support inline ternary expressions in object properties, resulting in cleaner and more intuitive code.

---

Let me know if you'd like to include implementation notes or link related issues/tickets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved class extraction to support conditional (ternary) expressions, ensuring all possible class variants are identified.
  * Enhanced prefix handling to include both original and camelCase variants for greater flexibility.

* **Tests**
  * Expanded test coverage to verify extraction from various conditional scenarios and ensure correct handling of new prefixes and deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->