### PR TITLE
feat(Select): improve generics to allow better typesaftey

### DIFF
--- a/packages/nuxt/playground/pages/components/select.vue
+++ b/packages/nuxt/playground/pages/components/select.vue
@@ -11,11 +11,11 @@ useForm({
 })
 
 const selected = ref<string>()
-const selected2 = ref()
-const selected3 = ref()
-const selectedMultiple = ref([])
-const selectedMultipleObj = ref([])
-const selectedStatus = ref()
+const selected2 = ref<string>()
+const selected3 = ref<string>()
+const selectedMultiple = ref<string[]>([])
+const selectedMultipleObj = ref<{ id: number, name: string, role: string }[]>()
+const selectedStatus = ref<string>()
 
 const alphabetItems = [
   {
@@ -86,7 +86,14 @@ const objectItems = [
         placeholder="Select Contributors"
         label="Vue Community"
         multiple
-      />
+      >
+        <template #trigger="{ modelValue }">
+          {{ modelValue }}
+        </template>
+        <template #item="{ item }">
+          {{ item }}
+        </template>
+      </NSelect>
       <pre class="mt-2">{{ selectedMultiple }}</pre>
     </div>
 
@@ -99,7 +106,11 @@ const objectItems = [
         :items="simpleItems"
         placeholder="Select Contributor"
         label="Vue Community"
-      />
+      >
+        <template #trigger="{ modelValue }">
+          {{ modelValue }}
+        </template>
+      </NSelect>
       <pre class="mt-2">{{ selected }}</pre>
     </div>
 

--- a/packages/nuxt/src/runtime/components/forms/select/Select.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/Select.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
 import type { AcceptableValue, SelectRootEmits } from 'reka-ui'
-import type { NSelectProps, SelectGroup as SelectGroupType } from '../../../types'
+import type { NSelectProps, NSelectSlots, SelectGroup as SelectGroupType } from '../../../types'
 import { computed } from 'vue'
 </script>
 
-<script setup lang="ts" generic="T extends AcceptableValue">
+<script setup lang="ts" generic="T extends AcceptableValue, I extends Array<T | SelectGroupType<T>>, M extends boolean = false">
 import { SelectRoot, useForwardPropsEmits } from 'reka-ui'
 import { cn, isEqualObject } from '../../../utils'
 import SelectContent from './SelectContent.vue'
@@ -15,11 +15,15 @@ import SelectSeparator from './SelectSeparator.vue'
 import SelectTrigger from './SelectTrigger.vue'
 import SelectValue from './SelectValue.vue'
 
-const props = withDefaults(defineProps<NSelectProps<T>>(), {
+type ModelType = (true extends M ? T[] : T) | null | undefined
+
+const props = withDefaults(defineProps<NSelectProps<T, I, M>>(), {
   size: 'sm',
 })
 
 const emits = defineEmits<SelectRootEmits<T>>()
+
+defineSlots<NSelectSlots<T, I, M>>()
 
 // Check if items are grouped
 const hasGroups = computed(() => {
@@ -76,8 +80,8 @@ function isItemSelected(item: unknown, modelValue: unknown) {
     )"
     v-bind="forwarded"
   >
-    <slot :model-value :open>
-      <slot name="trigger-wrapper" :model-value :open>
+    <slot :model-value="(modelValue as ModelType)" :open>
+      <slot name="trigger-wrapper" :model-value="(modelValue as ModelType)" :open>
         <SelectTrigger
           :id
           :size
@@ -86,7 +90,7 @@ function isItemSelected(item: unknown, modelValue: unknown) {
           v-bind="props._selectTrigger"
           :una
         >
-          <slot name="trigger" :model-value :open="open">
+          <slot name="trigger" :model-value="(modelValue as ModelType)" :open="open">
             <SelectValue
               :placeholder="props.placeholder"
               v-bind="props._selectValue"
@@ -94,7 +98,7 @@ function isItemSelected(item: unknown, modelValue: unknown) {
               :data-status="status"
               :una
             >
-              <slot name="value" :model-value :open>
+              <slot name="value" :model-value="(modelValue as ModelType)" :open>
                 {{ formatSelectedValue(modelValue) || props.placeholder }}
               </slot>
             </SelectValue>
@@ -193,7 +197,6 @@ function isItemSelected(item: unknown, modelValue: unknown) {
               </slot>
             </SelectGroup>
           </template>
-          <slot />
         </slot>
       </SelectContent>
     </slot>

--- a/packages/nuxt/src/runtime/types/select.ts
+++ b/packages/nuxt/src/runtime/types/select.ts
@@ -17,7 +17,7 @@ type ItemTextExtensions = SelectItemTextProps & BaseExtensions
 type GroupExtensions = SelectGroupProps & BaseExtensions
 type LabelExtensions = SelectLabelProps & BaseExtensions
 type SeparatorExtensions = SelectSeparatorProps & BaseExtensions
-type SelectExtensions = SelectRootProps
+type SelectExtensions<T extends AcceptableValue> = SelectRootProps<T>
   & BaseExtensions
   & Pick<NSelectValueProps, 'placeholder'>
   & Pick<NSelectItemProps, 'selectItem'>
@@ -30,11 +30,17 @@ export interface SelectGroup<T extends AcceptableValue> {
   _selectItem?: Partial<NSelectItemProps>
 }
 
-export interface NSelectProps<T extends AcceptableValue> extends SelectExtensions {
+type SelectModelType<T extends AcceptableValue, M extends boolean> = true extends M ? T[] : T
+
+export interface NSelectProps<
+  T extends AcceptableValue,
+  Items extends Array<T | SelectGroup<T>>,
+  M extends boolean = false,
+> extends SelectExtensions<T> {
   /**
    * The items to display in the select.
    */
-  items: T[] | SelectGroup<T>[]
+  items: Items
   /**
    * The key name to use to display in the select items.
    */
@@ -53,6 +59,13 @@ export interface NSelectProps<T extends AcceptableValue> extends SelectExtension
    * @default false
    */
   groupSeparator?: boolean
+
+  defaultValue?: SelectModelType<T, M>
+
+  modelValue?: SelectModelType<T, M>
+
+  multiple?: M
+
   /**
    * Sub-component configurations
    */
@@ -68,6 +81,43 @@ export interface NSelectProps<T extends AcceptableValue> extends SelectExtension
   _selectLabel?: Partial<NSelectLabelProps>
 
   una?: NSelectUnaProps
+}
+
+interface SelectModelSlotProps<T extends AcceptableValue, M extends boolean> {
+  modelValue: SelectModelType<T, M> | null | undefined
+  open: boolean
+}
+
+interface SelectContentSlotProps<T extends AcceptableValue, I extends Array<T | SelectGroup<T>>> {
+  items: I
+}
+
+interface SelectLabelSlotProps {
+  label: string | undefined
+}
+
+interface SelectItemSlotProps<T extends AcceptableValue, I extends Array<T | SelectGroup<T>>> {
+  item: I[number]
+}
+
+interface SelectGroupSlotProps<T extends AcceptableValue> {
+  items: SelectGroup<T>
+}
+
+export interface NSelectSlots<
+  T extends AcceptableValue,
+  I extends Array<T | SelectGroup<T>>,
+  M extends boolean = false,
+> {
+  'default': (props: SelectModelSlotProps<T, M>) => any
+  'trigger-wrapper': (props: SelectModelSlotProps<T, M>) => any
+  'trigger': (props: SelectModelSlotProps<T, M>) => any
+  'value': (props: SelectModelSlotProps<T, M>) => any
+  'content': (props: SelectContentSlotProps<T, I>) => any
+  'label': (props: SelectLabelSlotProps) => any
+  'item': (props: SelectItemSlotProps<T, I>) => any
+  'indicator': (props: SelectItemSlotProps<T, I>) => any
+  'group': (props: SelectGroupSlotProps<T>) => any
 }
 
 export interface NSelectTriggerProps extends TriggerExtensions {


### PR DESCRIPTION
i.e. `multiple` will enforce an array `modelValue`.

Types are improved by explicitly typing the slots via `defineSlots()` with generic typevars. I plan on doing similar changes for the other generic components later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced select components with improved customization options for displaying selected values and items using scoped slots.

* **Refactor**
  * Improved type safety and flexibility for select components, especially for multiple selection and grouped items, resulting in more robust and predictable behavior.

* **Style**
  * Cleaned up select component templates by removing unnecessary empty slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->