### PR TITLE
feat(types): improve generic typing for combobox and radio group components

### DIFF
--- a/docs/components/content/examples/vue/combobox/ExampleVueComboboxBasic.vue
+++ b/docs/components/content/examples/vue/combobox/ExampleVueComboboxBasic.vue
@@ -6,7 +6,7 @@ const frameworks = [
   { value: 'remix', label: 'Remix' },
   { value: 'astro', label: 'Astro' },
 ]
-const selectedFramework = ref()
+const selectedFramework = ref<typeof frameworks[number]>()
 </script>
 
 <template>

--- a/docs/components/content/examples/vue/combobox/ExampleVueComboboxContent.vue
+++ b/docs/components/content/examples/vue/combobox/ExampleVueComboboxContent.vue
@@ -6,7 +6,7 @@ const frameworks = [
   { value: 'remix', label: 'Remix' },
   { value: 'astro', label: 'Astro' },
 ]
-const selectedFramework = ref()
+const selectedFramework = ref<typeof frameworks[number]>()
 </script>
 
 <template>

--- a/docs/components/content/examples/vue/combobox/ExampleVueComboboxFormField.vue
+++ b/docs/components/content/examples/vue/combobox/ExampleVueComboboxFormField.vue
@@ -21,7 +21,7 @@ const frameworks = [
   { value: 'remix', label: 'Remix' },
   { value: 'astro', label: 'Astro' },
 ]
-const selectedFramework = ref()
+const selectedFramework = ref<typeof frameworks[number]>()
 </script>
 
 <template>

--- a/docs/components/content/examples/vue/combobox/ExampleVueComboboxMultiple.vue
+++ b/docs/components/content/examples/vue/combobox/ExampleVueComboboxMultiple.vue
@@ -6,7 +6,7 @@ const frameworks = [
   { value: 'remix', label: 'Remix' },
   { value: 'astro', label: 'Astro' },
 ]
-const selectedFramework = ref()
+const selectedFramework = ref<typeof frameworks[number][]>()
 </script>
 
 <template>

--- a/docs/components/content/examples/vue/combobox/ExampleVueComboboxSize.vue
+++ b/docs/components/content/examples/vue/combobox/ExampleVueComboboxSize.vue
@@ -6,7 +6,7 @@ const frameworks = [
   { value: 'remix', label: 'Remix' },
   { value: 'astro', label: 'Astro' },
 ]
-const selectedFramework = ref()
+const selectedFramework = ref<typeof frameworks[number]>()
 </script>
 
 <template>

--- a/docs/components/content/examples/vue/combobox/ExampleVueComboboxSlotDefault.vue
+++ b/docs/components/content/examples/vue/combobox/ExampleVueComboboxSlotDefault.vue
@@ -6,7 +6,7 @@ const frameworks = [
   { value: 'remix', label: 'Remix' },
   { value: 'astro', label: 'Astro' },
 ]
-const selectedFramework = ref()
+const selectedFramework = ref<typeof frameworks[number]>()
 </script>
 
 <template>

--- a/docs/components/content/examples/vue/combobox/ExampleVueComboboxSlotMultiple.vue
+++ b/docs/components/content/examples/vue/combobox/ExampleVueComboboxSlotMultiple.vue
@@ -6,7 +6,7 @@ const frameworks = [
   { value: 'remix', label: 'Remix' },
   { value: 'astro', label: 'Astro' },
 ]
-const selectedFrameworks = ref([])
+const selectedFrameworks = ref<typeof frameworks[number][]>([])
 </script>
 
 <template>
@@ -24,10 +24,10 @@ const selectedFrameworks = ref([])
         align: 'start',
       }"
     >
-      <template #trigger>
-        {{ selectedFrameworks?.length > 0
-          ? selectedFrameworks.map(val => {
-            const framework = frameworks.find(f => f.value === val)
+      <template #trigger="{ modelValue }">
+        {{ modelValue?.length
+          ? modelValue.map(val => {
+            const framework = frameworks.find(f => f.value === val.value)
             return framework ? framework.label : val
           }).join(", ")
           : "Select frameworks..." }}

--- a/docs/components/content/examples/vue/combobox/ExampleVueComboboxTrigger.vue
+++ b/docs/components/content/examples/vue/combobox/ExampleVueComboboxTrigger.vue
@@ -4,7 +4,7 @@ const users = [
   { id: '2', username: 'leerob' },
   { id: '3', username: 'evilrabbit' },
 ]
-const selectedUser = ref()
+const selectedUser = ref<typeof users[number]>()
 </script>
 
 <template>
@@ -17,15 +17,15 @@ const selectedUser = ref()
         placeholder: 'Select user...',
       }"
     >
-      <template #trigger>
-        <template v-if="selectedUser">
+      <template #trigger="{ modelValue }">
+        <template v-if="modelValue">
           <div class="flex items-center gap-2">
             <NAvatar
-              :src="`https://github.com/${selectedUser.username}.png`"
-              :alt="selectedUser.username"
+              :src="`https://github.com/${modelValue.username}.png`"
+              :alt="modelValue.username"
               square="5"
             />
-            {{ selectedUser.username }}
+            {{ modelValue.username }}
           </div>
         </template>
         <template v-else>

--- a/docs/components/content/examples/vue/select/ExampleVueSelectBasic.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectBasic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const selected = ref()
+const selected = ref<string>()
 const items = ['Evan You', 'Anthony Fu', 'Daniel Roe', 'Pooya Parsa', 'Sébastien Chopin', 'Alexander Lichter']
 </script>
 

--- a/docs/components/content/examples/vue/select/ExampleVueSelectColor.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectColor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const selected = ref()
+const selected = ref<string>()
 const items = ['Evan You', 'Anthony Fu', 'Daniel Roe', 'Pooya Parsa', 'Sébastien Chopin', 'Alexander Lichter']
 </script>
 

--- a/docs/components/content/examples/vue/select/ExampleVueSelectDisabled.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectDisabled.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const selected = ref()
+const selected = ref<string>()
 const items = ['Evan You', 'Anthony Fu', 'Daniel Roe', 'Pooya Parsa', 'Sébastien Chopin', 'Alexander Lichter']
 </script>
 

--- a/docs/components/content/examples/vue/select/ExampleVueSelectGroup.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const selected = ref()
+const selected = ref<string>()
 const items = [
   {
     label: 'A',

--- a/docs/components/content/examples/vue/select/ExampleVueSelectMultiple.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectMultiple.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const selected = ref([])
+const selected = ref<string[]>([])
 const items = ['Evan You', 'Anthony Fu', 'Daniel Roe', 'Pooya Parsa', 'Sébastien Chopin', 'Alexander Lichter']
 </script>
 

--- a/docs/components/content/examples/vue/select/ExampleVueSelectObjects.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectObjects.vue
@@ -18,7 +18,7 @@ const items = [
   },
 ]
 
-const selected = ref()
+const selected = ref<typeof items[number]>()
 </script>
 
 <template>

--- a/docs/components/content/examples/vue/select/ExampleVueSelectSize.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectSize.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const selected = ref()
+const selected = ref<string>()
 const items = ['Evan You', 'Anthony Fu', 'Daniel Roe', 'Pooya Parsa', 'Sébastien Chopin', 'Alexander Lichter']
 </script>
 

--- a/docs/components/content/examples/vue/select/ExampleVueSelectSlots.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectSlots.vue
@@ -47,14 +47,14 @@ const selected = ref(items[0])
         </div>
       </template>
 
-      <template #value>
+      <template #value="{ modelValue }">
         <div class="flex items-center space-x-2">
           <img
-            :src="selected?.avatar"
-            :alt="selected?.name"
+            :src="modelValue?.avatar"
+            :alt="modelValue?.name"
             class="h-6 w-6 rounded-full"
           >
-          <span>{{ selected?.name }}</span>
+          <span>{{ modelValue?.name }}</span>
         </div>
       </template>
     </NSelect>

--- a/docs/components/content/examples/vue/table/ExampleVueTableRowSelection.vue
+++ b/docs/components/content/examples/vue/table/ExampleVueTableRowSelection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ColumnDef, Table } from '@tanstack/vue-table'
+import type { ColumnDef, RowSelectionState, Table } from '@tanstack/vue-table'
 import type { Person } from './makeData'
 import makeData from './makeData'
 
@@ -32,7 +32,7 @@ const columns: ColumnDef<Person>[] = [
   },
 ]
 
-const select = ref()
+const select = ref<RowSelectionState>()
 const table = useTemplateRef<Table<Person>>('table')
 </script>
 

--- a/docs/components/content/examples/vue/table/ExampleVueTableSlots.vue
+++ b/docs/components/content/examples/vue/table/ExampleVueTableSlots.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ColumnDef, Table } from '@tanstack/vue-table'
+import type { ColumnDef, RowSelectionState, Table } from '@tanstack/vue-table'
 import type { Person } from './makeData'
 import { NAvatar } from '#components'
 
@@ -66,7 +66,7 @@ const columns: ColumnDef<Person>[] = [
 ]
 
 const search = ref('')
-const select = ref()
+const select = ref<RowSelectionState>()
 
 const table = useTemplateRef<Table<Person>>('table')
 </script>
@@ -110,7 +110,7 @@ const table = useTemplateRef<Table<Person>>('table')
       :columns
       :data
       :global-filter="search"
-      enable-column-filters enable-row-selection enable-sorting
+      enable-row-selection enable-column-filters enable-sorting
       row-id="username"
     >
       <!-- filters -->

--- a/docs/components/content/examples/vue/table/ExampleVueTableVisibility.vue
+++ b/docs/components/content/examples/vue/table/ExampleVueTableVisibility.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import type { ColumnDef, Table } from '@tanstack/vue-table'
+import type { ColumnDef, Table, VisibilityState } from '@tanstack/vue-table'
 import type { Person } from './makeData'
 import makeData from './makeData'
 
 const data = ref(makeData(5))
 
-const columns: ColumnDef<Person>[] = [
+const columns = [
   {
     header: 'First Name',
     accessorKey: 'firstName',
@@ -30,11 +30,11 @@ const columns: ColumnDef<Person>[] = [
     header: 'Profile Progress',
     accessorKey: 'progress',
   },
-]
+] satisfies ColumnDef<Person>[]
 
 const table = useTemplateRef<Table<Person>>('table')
 
-const columnVisibility = ref({})
+const columnVisibility = ref<VisibilityState>({})
 </script>
 
 <template>

--- a/packages/nuxt/playground/components/project-management/TableIssues.vue
+++ b/packages/nuxt/playground/components/project-management/TableIssues.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ColumnDef, Table } from '@tanstack/vue-table'
+import type { ColumnDef, RowSelectionState, Table } from '@tanstack/vue-table'
 import type { Issue } from '../../data'
 import { NAvatar } from '#components'
 
@@ -23,7 +23,7 @@ async function addIssues(count: number) {
   limit.value += count
 }
 
-const columns: ColumnDef<Issue>[] = [
+const columns = [
   {
     header: 'Title',
     accessorKey: 'title',
@@ -196,9 +196,9 @@ const columns: ColumnDef<Issue>[] = [
     enableSorting: false,
     enableColumnFilter: false,
   },
-]
+] satisfies ColumnDef<Issue>[]
 const search = ref('')
-const select = ref()
+const select = ref<RowSelectionState>()
 const table = useTemplateRef<Table<Issue>>('table')
 
 // Set initial column visibility
@@ -235,7 +235,7 @@ const visibleColumnHeaders = computed({
         const col = columns.find(col =>
           ('accessorKey' in col && col.accessorKey === key),
         )
-        return col?.header
+        return col?.header as string
       })
       .filter(Boolean)
   },

--- a/packages/nuxt/playground/pages/components/combobox.vue
+++ b/packages/nuxt/playground/pages/components/combobox.vue
@@ -6,15 +6,15 @@ const frameworks = [
   { value: 'remix', label: 'Remix' },
   { value: 'astro', label: 'Astro' },
 ]
-const selectedFramework = ref()
-const selectedFrameworks = ref([])
+const selectedFramework = ref<typeof frameworks[number]>()
+const selectedFrameworks = ref<typeof frameworks[number][]>([])
 
 const users = [
   { id: '1', username: 'shadcn' },
   { id: '2', username: 'leerob' },
   { id: '3', username: 'evilrabbit' },
 ]
-const selectedUser = ref()
+const selectedUser = ref<typeof users[number]>()
 
 const timezones = [
   {
@@ -112,15 +112,15 @@ const selectedGroup = computed(() => timezones.find(group => group.items.find(tz
         placeholder: 'Select user...',
       }"
     >
-      <template #trigger>
-        <template v-if="selectedUser">
+      <template #trigger="{ modelValue }">
+        <template v-if="modelValue">
           <div class="flex items-center gap-2">
             <NAvatar
-              :src="`https://github.com/${selectedUser.username}.png`"
-              :alt="selectedUser.username"
+              :src="`https://github.com/${modelValue.username}.png`"
+              :alt="modelValue.username"
               square="5"
             />
-            {{ selectedUser.username }}
+            {{ modelValue.username }}
           </div>
         </template>
         <template v-else>
@@ -166,13 +166,13 @@ const selectedGroup = computed(() => timezones.find(group => group.items.find(tz
         class: 'h-12 px-2.5',
       }"
     >
-      <template #trigger>
-        <template v-if="selectedTimezone">
+      <template #trigger="{ modelValue }">
+        <template v-if="modelValue">
           <div class="flex flex-col items-start gap-0.5">
             <span class="text-xs font-normal opacity-75">
               {{ selectedGroup?.label }}
             </span>
-            <span>{{ selectedTimezone.label }}</span>
+            <span>{{ modelValue.label }}</span>
           </div>
         </template>
         <template v-else>
@@ -196,10 +196,10 @@ const selectedGroup = computed(() => timezones.find(group => group.items.find(tz
       :_combobox-anchor="{
       }"
     >
-      <template #trigger>
-        {{ selectedFrameworks?.length > 0
-          ? selectedFrameworks.map(val => {
-            const framework = frameworks.find(f => f.value === val)
+      <template #trigger="{ modelValue }">
+        {{ modelValue?.length
+          ? modelValue.map(val => {
+            const framework = frameworks.find(f => f.value === val.value)
             return framework ? framework.label : val
           }).join(", ")
           : "Select frameworks (multi-select)..." }}

--- a/packages/nuxt/playground/pages/components/table.vue
+++ b/packages/nuxt/playground/pages/components/table.vue
@@ -1,22 +1,22 @@
 <script setup lang="ts">
-import type { Table } from '@tanstack/vue-table'
+import type { ColumnDef, ColumnFiltersState, RowSelectionState, SortingState } from '@tanstack/vue-table'
 
 const autoReset = ref(false)
-const select = ref()
-const sorting = ref()
+const select = ref<RowSelectionState>()
+const sorting = ref<SortingState>()
 const visibleColumns = ref({
   selection: true,
   age: true,
   lastName: true,
   firstName: true,
 })
-const filter = ref()
-const columnFilters = ref()
+const filter = ref<string>()
+const columnFilters = ref<ColumnFiltersState>()
 const pagination = ref({
   pageIndex: 0,
   pageSize: 5,
 })
-const table = ref<Table<any>>()
+const table = useTemplateRef('table')
 
 const columns = [
   // Types issue
@@ -36,7 +36,7 @@ const columns = [
     accessorKey: 'actions',
     header: 'Actions',
   },
-]
+] satisfies ColumnDef<ResourceMeta['results'][number]>[]
 
 /**
  * @name NTable

--- a/packages/nuxt/src/runtime/components/combobox/Combobox.vue
+++ b/packages/nuxt/src/runtime/components/combobox/Combobox.vue
@@ -7,7 +7,7 @@ import { ComboboxRoot, useForwardPropsEmits } from 'reka-ui'
 import { cn } from '../../utils'
 </script>
 
-<script setup lang="ts" generic="T extends AcceptableValue">
+<script setup lang="ts" generic="T extends AcceptableValue, M extends boolean = false">
 import { computed } from 'vue'
 import ComboboxAnchor from './ComboboxAnchor.vue'
 import ComboboxEmpty from './ComboboxEmpty.vue'
@@ -20,7 +20,7 @@ import ComboboxSeparator from './ComboboxSeparator.vue'
 import ComboboxTrigger from './ComboboxTrigger.vue'
 import ComboboxViewport from './ComboboxViewport.vue'
 
-const props = withDefaults(defineProps<NComboboxProps<T>>(), {
+const props = withDefaults(defineProps<NComboboxProps<T, M>>(), {
   textEmpty: 'No items found.',
   size: 'sm',
 })
@@ -139,7 +139,6 @@ function isItemSelected(item: ExtractItemType<T> | null | undefined): boolean {
 
 <template>
   <ComboboxRoot
-    v-slot="{ modelValue, open }"
     data-slot="combobox"
     :class="cn(
       'combobox',

--- a/packages/nuxt/src/runtime/components/forms/radio-group/RadioGroup.vue
+++ b/packages/nuxt/src/runtime/components/forms/radio-group/RadioGroup.vue
@@ -3,13 +3,13 @@ import type { AcceptableValue, RadioGroupRootEmits } from 'reka-ui'
 import type { NRadioGroupItemProps, NRadioGroupProps } from '../../../types'
 </script>
 
-<script setup lang="ts" generic="T extends AcceptableValue">
+<script setup lang="ts" generic="T extends AcceptableValue, Item extends T | NRadioGroupItemProps<T>">
 import { reactivePick } from '@vueuse/core'
 import { RadioGroupRoot, useForwardPropsEmits } from 'reka-ui'
 import { cn } from '../../../utils'
 import RadioGroupItem from './RadioGroupItem.vue'
 
-const props = withDefaults(defineProps<NRadioGroupProps<T>>(), {
+const props = withDefaults(defineProps<NRadioGroupProps<T, Item>>(), {
   radioGroup: 'primary',
   size: 'md',
   square: '1em',
@@ -67,7 +67,6 @@ function getItemDescription(item: NonNullable<T | NRadioGroupItemProps>): string
 
 <template>
   <RadioGroupRoot
-    v-slot="{ modelValue }"
     :class="cn(
       'radio-group',
       orientation === 'horizontal' ? 'radio-group-orientation-horizontal' : 'radio-group-orientation-vertical',

--- a/packages/nuxt/src/runtime/components/forms/select/Select.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/Select.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { AcceptableValue, SelectRootEmits } from 'reka-ui'
-import type { NSelectProps, NSelectSlots, SelectGroup as SelectGroupType } from '../../../types'
+import type { NSelectProps, SelectGroup as SelectGroupType } from '../../../types'
 import { computed } from 'vue'
 </script>
 
@@ -15,15 +15,11 @@ import SelectSeparator from './SelectSeparator.vue'
 import SelectTrigger from './SelectTrigger.vue'
 import SelectValue from './SelectValue.vue'
 
-type ModelType = (true extends M ? T[] : T) | null | undefined
-
 const props = withDefaults(defineProps<NSelectProps<T, I, M>>(), {
   size: 'sm',
 })
 
 const emits = defineEmits<SelectRootEmits<T>>()
-
-defineSlots<NSelectSlots<T, I, M>>()
 
 // Check if items are grouped
 const hasGroups = computed(() => {
@@ -73,15 +69,14 @@ function isItemSelected(item: unknown, modelValue: unknown) {
 
 <template>
   <SelectRoot
-    v-slot="{ modelValue, open }"
     :class="cn(
       props.una?.select,
       props.class,
     )"
     v-bind="forwarded"
   >
-    <slot :model-value="(modelValue as ModelType)" :open>
-      <slot name="trigger-wrapper" :model-value="(modelValue as ModelType)" :open>
+    <slot :model-value :open>
+      <slot name="trigger-wrapper" :model-value :open>
         <SelectTrigger
           :id
           :size
@@ -90,7 +85,7 @@ function isItemSelected(item: unknown, modelValue: unknown) {
           v-bind="props._selectTrigger"
           :una
         >
-          <slot name="trigger" :model-value="(modelValue as ModelType)" :open="open">
+          <slot name="trigger" :model-value :open="open">
             <SelectValue
               :placeholder="props.placeholder"
               v-bind="props._selectValue"
@@ -98,7 +93,7 @@ function isItemSelected(item: unknown, modelValue: unknown) {
               :data-status="status"
               :una
             >
-              <slot name="value" :model-value="(modelValue as ModelType)" :open>
+              <slot name="value" :model-value :open>
                 {{ formatSelectedValue(modelValue) || props.placeholder }}
               </slot>
             </SelectValue>

--- a/packages/nuxt/src/runtime/types/combobox.ts
+++ b/packages/nuxt/src/runtime/types/combobox.ts
@@ -12,12 +12,12 @@ interface BaseExtensions {
 // Extract the actual item type when dealing with grouped items
 export type ExtractItemType<T> = T extends { items: infer I extends AcceptableValue[] } ? I[number] : T
 
-export interface NComboboxProps<T extends AcceptableValue> extends Omit<ComboboxRootProps<ExtractItemType<T>>, 'modelValue'>, Pick<NComboboxInputProps, 'status' | 'id'>, BaseExtensions {
+export interface NComboboxProps<T extends AcceptableValue, M extends boolean> extends Omit<ComboboxRootProps<ExtractItemType<T>>, 'modelValue'>, Pick<NComboboxInputProps, 'status' | 'id'>, BaseExtensions {
   /**
    * The model value for the combobox.
    * When using grouped items, this will be the item type from within the groups.
    */
-  modelValue?: ExtractItemType<T> | ExtractItemType<T>[] | null | undefined
+  modelValue?: (M extends true ? ExtractItemType<T>[] : ExtractItemType<T>) | null
 
   /**
    * The items to display in the combobox.
@@ -55,6 +55,9 @@ export interface NComboboxProps<T extends AcceptableValue> extends Omit<Combobox
    * @default ''
    */
   label?: string
+
+  multiple?: M
+
   /**
    * Sub-component configurations
    */

--- a/packages/nuxt/src/runtime/types/radio-group.ts
+++ b/packages/nuxt/src/runtime/types/radio-group.ts
@@ -24,11 +24,12 @@ interface BaseProps {
   icon?: HTMLAttributes['class']
 }
 
-export interface NRadioGroupProps<T extends AcceptableValue> extends BaseProps, RadioGroupRootProps {
+export interface NRadioGroupProps<T extends AcceptableValue, Item extends T | NRadioGroupItemProps<T>> extends BaseProps, RadioGroupRootProps {
+  modelValue: T
   /**
    * The items to display in the radio group.
    */
-  items?: T[] | NRadioGroupItemProps[]
+  items?: Item[]
   /**
    * The key name to use to display in the radio items.
    */
@@ -64,7 +65,8 @@ export interface NRadioGroupProps<T extends AcceptableValue> extends BaseProps, 
   una?: NRadioGroupUnaProps
 }
 
-export interface NRadioGroupItemProps extends BaseProps, RadioGroupItemProps {
+export interface NRadioGroupItemProps<T extends AcceptableValue = any> extends BaseProps, RadioGroupItemProps {
+  value: T
   /**
    * The label to display in the radio item.
    */

--- a/packages/nuxt/src/runtime/types/select.ts
+++ b/packages/nuxt/src/runtime/types/select.ts
@@ -30,8 +30,6 @@ export interface SelectGroup<T extends AcceptableValue> {
   _selectItem?: Partial<NSelectItemProps>
 }
 
-type SelectModelType<T extends AcceptableValue, M extends boolean> = true extends M ? T[] : T
-
 export interface NSelectProps<
   T extends AcceptableValue,
   Items extends Array<T | SelectGroup<T>>,
@@ -60,9 +58,9 @@ export interface NSelectProps<
    */
   groupSeparator?: boolean
 
-  defaultValue?: SelectModelType<T, M>
+  defaultValue?: M extends true ? T[] : T
 
-  modelValue?: SelectModelType<T, M>
+  modelValue?: M extends true ? T[] : T
 
   multiple?: M
 
@@ -81,43 +79,6 @@ export interface NSelectProps<
   _selectLabel?: Partial<NSelectLabelProps>
 
   una?: NSelectUnaProps
-}
-
-interface SelectModelSlotProps<T extends AcceptableValue, M extends boolean> {
-  modelValue: SelectModelType<T, M> | null | undefined
-  open: boolean
-}
-
-interface SelectContentSlotProps<T extends AcceptableValue, I extends Array<T | SelectGroup<T>>> {
-  items: I
-}
-
-interface SelectLabelSlotProps {
-  label: string | undefined
-}
-
-interface SelectItemSlotProps<T extends AcceptableValue, I extends Array<T | SelectGroup<T>>> {
-  item: I[number]
-}
-
-interface SelectGroupSlotProps<T extends AcceptableValue> {
-  items: SelectGroup<T>
-}
-
-export interface NSelectSlots<
-  T extends AcceptableValue,
-  I extends Array<T | SelectGroup<T>>,
-  M extends boolean = false,
-> {
-  'default': (props: SelectModelSlotProps<T, M>) => any
-  'trigger-wrapper': (props: SelectModelSlotProps<T, M>) => any
-  'trigger': (props: SelectModelSlotProps<T, M>) => any
-  'value': (props: SelectModelSlotProps<T, M>) => any
-  'content': (props: SelectContentSlotProps<T, I>) => any
-  'label': (props: SelectLabelSlotProps) => any
-  'item': (props: SelectItemSlotProps<T, I>) => any
-  'indicator': (props: SelectItemSlotProps<T, I>) => any
-  'group': (props: SelectGroupSlotProps<T>) => any
 }
 
 export interface NSelectTriggerProps extends TriggerExtensions {


### PR DESCRIPTION
Similar changes to #466 and introduces generics for `multiple` and `items` when relevant.

Also removes the explicit `defineSlots` in `NSelect`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across various Vue component examples by adding explicit TypeScript type annotations to reactive references.
  * Updated slot usage in several components to use slot-provided values, enhancing clarity and consistency in templates.
  * Enhanced generic type definitions and prop typings in combobox, radio group, and select components for more precise type inference and flexibility.
  * Removed unused or redundant type aliases and slot interfaces to simplify type declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->