### PR TITLE
fix(Stepper): hasNext and hasPrev have an offset of 1

### DIFF
--- a/packages/nuxt/src/runtime/components/stepper/Stepper.vue
+++ b/packages/nuxt/src/runtime/components/stepper/Stepper.vue
@@ -68,8 +68,8 @@ defineExpose({
     stepper.value?.prevStep()
     emits('prev', currentStep.value)
   },
-  hasNext: () => stepper.value?.hasNext(),
-  hasPrev: () => stepper.value?.hasPrev(),
+  hasNext: () => hasNextStep.value,
+  hasPrev: () => hasPrevStep.value,
 })
 </script>
 


### PR DESCRIPTION
![una-ui-stepper](https://github.com/user-attachments/assets/99321080-f75d-436d-90fe-4fe5c05b4d16)

When using the new, neat stepper component, I wanted to disable the _previous_  &  _next_ buttons accordingly:

```
    <NButton
      label="prev"
      btn="soft-primary hover:outline-primary"
      leading="i-lucide-arrow-left"
      @click="stepper?.prevStep()"
      :disabled="!stepper?.hasPrev()"
    />
```
 
However, it seems that there is an offset of 1 relative to the items. `hasPrev()` already switches to `false` at the second step and `hasNext()` is still `true` at the last. 
 
I think, the intention was to expose the computed values of `hasNextStep` and `hasPrevStep` from the component, which should fix the issue (not tested though, since I am unfamiliar with setting up a development and test environment for a JS library). 

Thanks
Matthias

PS: This proposed fix is not urgent at all, so no need to tackle it soon.