### PR TITLE
fix(extractor): ignore unsupported filetypes

### DIFF
--- a/packages/extractor-vue-script/src/index.test.ts
+++ b/packages/extractor-vue-script/src/index.test.ts
@@ -9,7 +9,7 @@ const prefixes = [
 
 const extractor = extractorVueScript({ prefixes })
 
-async function extract(code: string, id?: string): Promise<string[]> {
+async function extract(code: string, id: string = 'index.js'): Promise<string[]> {
   const extracted = new Set<string>()
   const result = await extractor.extract!({ original: code, code, id, extracted })
   if (result) {
@@ -233,4 +233,14 @@ const config = {
   expect(result).toContain('[badge~="solid-blue"]')
   expect(result).toContain('[badge~="outline-primary"]')
   expect(result).toContain('[btn~="ghost-lime"]')
+})
+
+it('unsupported filetypes should be ignored', async () => {
+  const code = `
+# Index
+
+Hello, world!
+`
+  const result = await extract(code, 'index.md')
+  expect(result).toStrictEqual([])
 })

--- a/packages/extractor-vue-script/src/index.ts
+++ b/packages/extractor-vue-script/src/index.ts
@@ -112,10 +112,15 @@ function discoverVariants(node: babel.Node, prefixes: string[]): string[] {
 }
 
 function parseCodeAst(code: string, id?: string) {
-  const { $ast: node } = parseModule(code, {
-    sourceFileName: id,
-  })
-  return node
+  try {
+    const { $ast: node } = parseModule(code, {
+      sourceFileName: id,
+    })
+    return node
+  }
+  catch (e) {
+    throw new SyntaxError(`Failed to parse code ast${id ? ` (file: ${id})` : ''}`, { cause: e })
+  }
 }
 
 function extractTemplateExpressions(node: RootNode): babel.Node[] {

--- a/packages/extractor-vue-script/src/index.ts
+++ b/packages/extractor-vue-script/src/index.ts
@@ -142,14 +142,21 @@ function extractTemplateExpressions(node: RootNode): babel.Node[] {
   return expressions
 }
 
+// only process supported filetypes
+const SUPPORTED_EXTENSION_IDS = /\.(?:[mc]?[jt]sx?|vue)$/
+
 function extractorVueScript(options?: ExtractorVueScriptOptions): Extractor {
   return {
     name: '@una-ui/extractor-vue-script',
     order: 0,
     async extract({ code, id }) {
       // the id can contain query parameters, so we need to clean it up
-      const astExprs = []
       const cleanPath = parsePath(id).pathname
+      // only process supported file extensions
+      if (!SUPPORTED_EXTENSION_IDS.test(cleanPath)) {
+        return undefined
+      }
+      const astExprs = []
       if (cleanPath.endsWith('.vue')) {
         const sfc = parseSFC(code, {
           filename: cleanPath,


### PR DESCRIPTION
And include the filename in parsing error messages.

Fixes #516 