### PR TITLE
fix(Select): Support indicators when items are provided via content slot

### DIFF
--- a/packages/nuxt/playground/pages/components/select.vue
+++ b/packages/nuxt/playground/pages/components/select.vue
@@ -16,6 +16,7 @@ const selected3 = ref<string>()
 const selectedMultiple = ref<string[]>([])
 const selectedMultipleObj = ref<{ id: number, name: string, role: string }[]>()
 const selectedStatus = ref<string>()
+const selectedCustom = ref<string>()
 
 const alphabetItems = [
   {
@@ -189,6 +190,27 @@ const objectItems = [
           label="Vue Community"
           status="error"
         />
+      </div>
+    </div>
+
+    <div class="max-w-50 flex flex-col space-y-2">
+      <NLabel>
+        Custom Content Items
+      </NLabel>
+      <div clas="space-y-2">
+        <NSelect v-model="selectedCustom">
+          <template #content>
+            <NSelectItem value="custom-1">
+              Custom Item 1
+            </NSelectItem>
+            <NSelectItem value="custom-2" disabled>
+              Custom Item 2 (Disabled)
+            </NSelectItem>
+            <NSelectItem value="custom-3">
+              Custom Item 3
+            </NSelectItem>
+          </template>
+        </NSelect>
       </div>
     </div>
   </div>

--- a/packages/nuxt/playground/pages/components/select.vue
+++ b/packages/nuxt/playground/pages/components/select.vue
@@ -197,7 +197,7 @@ const objectItems = [
       <NLabel>
         Custom Content Items
       </NLabel>
-      <div clas="space-y-2">
+      <div class="space-y-2">
         <NSelect v-model="selectedCustom">
           <template #content>
             <NSelectItem value="custom-1">

--- a/packages/nuxt/src/runtime/components/forms/select/Select.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/Select.vue
@@ -6,7 +6,7 @@ import { computed } from 'vue'
 
 <script setup lang="ts" generic="T extends AcceptableValue, I extends Array<T | SelectGroupType<T>>, M extends boolean = false">
 import { SelectRoot, useForwardPropsEmits } from 'reka-ui'
-import { cn, isEqualObject } from '../../../utils'
+import { cn } from '../../../utils'
 import SelectContent from './SelectContent.vue'
 import SelectGroup from './SelectGroup.vue'
 import SelectItem from './SelectItem.vue'
@@ -47,23 +47,6 @@ function formatSelectedValue(value: unknown) {
   }
 
   return value
-}
-
-function isItemSelected(item: unknown, modelValue: unknown) {
-  if (!modelValue)
-    return false
-
-  if (props.multiple && Array.isArray(modelValue)) {
-    return modelValue.some((val) => {
-      const valObj = typeof val === 'object' && val ? val : { value: val }
-      const itemObj = typeof item === 'object' && item ? item : { value: item }
-      return isEqualObject(valObj, itemObj)
-    })
-  }
-
-  const modelObj = typeof modelValue === 'object' && modelValue ? modelValue : { value: modelValue }
-  const itemObj = typeof item === 'object' && item ? item : { value: item }
-  return isEqualObject(modelObj, itemObj)
 }
 </script>
 
@@ -131,7 +114,6 @@ function isItemSelected(item: unknown, modelValue: unknown) {
                 :size
                 :select-item
                 v-bind="props._selectItem"
-                :is-selected="isItemSelected(item, modelValue)"
                 :una
               >
                 <slot name="item" :item="item">
@@ -178,7 +160,6 @@ function isItemSelected(item: unknown, modelValue: unknown) {
                     :size
                     :select-item
                     v-bind="{ ..._selectItem, ...group._selectItem }"
-                    :is-selected="isItemSelected(item, modelValue)"
                     :una
                   >
                     <slot name="item" :item="item">

--- a/packages/nuxt/src/runtime/components/forms/select/SelectItem.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectItem.vue
@@ -31,7 +31,6 @@ const forwardedProps = useForwardProps(delegatedProps)
     :select-item
   >
     <SelectItemIndicator
-      v-if="isSelected"
       :una
       v-bind="props._selectItemIndicator"
     >

--- a/packages/nuxt/src/runtime/components/forms/select/SelectItemIndicator.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectItemIndicator.vue
@@ -1,17 +1,14 @@
 <script setup lang="ts">
 import type { NSelectItemIndicatorProps } from '../../../types'
-import { Primitive } from 'reka-ui'
+import { SelectItemIndicator } from 'reka-ui'
 import { cn } from '../../../utils'
 import Icon from '../../elements/Icon.vue'
 
-const props = withDefaults(defineProps<NSelectItemIndicatorProps>(), {
-  as: 'span',
-})
+const props = defineProps<NSelectItemIndicatorProps>()
 </script>
 
 <template>
-  <Primitive
-    aria-hidden
+  <SelectItemIndicator
     v-bind="props"
     :class="cn(
       'select-item-indicator',
@@ -27,5 +24,5 @@ const props = withDefaults(defineProps<NSelectItemIndicatorProps>(), {
         )"
       />
     </slot>
-  </Primitive>
+  </SelectItemIndicator>
 </template>

--- a/packages/nuxt/src/runtime/components/forms/select/SelectItemIndicator.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectItemIndicator.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
 import type { NSelectItemIndicatorProps } from '../../../types'
-import { SelectItemIndicator } from 'reka-ui'
+import { reactiveOmit } from '@vueuse/core'
+import { SelectItemIndicator, useForwardProps } from 'reka-ui'
 import { cn } from '../../../utils'
 import Icon from '../../elements/Icon.vue'
 
 const props = defineProps<NSelectItemIndicatorProps>()
+
+const forwardProps = useForwardProps(reactiveOmit(props, ['icon', 'una']))
 </script>
 
 <template>
   <SelectItemIndicator
-    v-bind="props"
+    v-bind="forwardProps"
     :class="cn(
       'select-item-indicator',
       props.una?.selectItemIndicator,

--- a/packages/nuxt/src/runtime/types/select.ts
+++ b/packages/nuxt/src/runtime/types/select.ts
@@ -38,7 +38,7 @@ export interface NSelectProps<
   /**
    * The items to display in the select.
    */
-  items: Items
+  items?: Items
   /**
    * The key name to use to display in the select items.
    */
@@ -134,7 +134,6 @@ export interface NSelectItemIndicatorProps extends SelectItemIndicatorProps {
 
 export interface NSelectItemProps extends ItemExtensions {
   selectItem?: HTMLAttributes['class']
-  isSelected?: boolean
   _selectItemText?: NSelectItemTextProps
   _selectItemIndicator?: NSelectItemIndicatorProps
   una?: Pick<NSelectUnaProps, 'selectItem' | 'selectItemIndicator'>


### PR DESCRIPTION
Uses the SelectItemIndicator provided by reka, which checks item selection automatically.

Also marks items prop as optional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a “Custom Content Items” example to the Select demo with customizable item content.

- Refactor
  - Simplified selection handling in Select so selection is inferred rather than explicitly passed.
  - Updated Select item indicator to render via a unified indicator component.
  - Made the Select items input optional for more flexible configurations.

- Bug Fixes
  - Improved consistency of selection indicator display across Select items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->