### PR TITLE
fix(themes): omit 'themes' from una-settings local storage

### DIFF
--- a/packages/nuxt/src/runtime/composables/useUnaSettings.ts
+++ b/packages/nuxt/src/runtime/composables/useUnaSettings.ts
@@ -6,8 +6,8 @@ import { defu } from 'defu'
 import { useUnaThemes } from './useUnaThemes'
 
 export interface UseUnaSettingsReturn {
-  defaultSettings: UnaSettings
-  settings: Ref<UnaSettings>
+  defaultSettings: Omit<UnaSettings, 'themes'>
+  settings: Ref<Omit<UnaSettings, 'themes'>>
   reset: () => void
 }
 
@@ -15,7 +15,7 @@ export function useUnaSettings(): UseUnaSettingsReturn {
   const { una } = useAppConfig()
   const { getPrimaryColors, getGrayColors } = useUnaThemes()
 
-  const defaultSettings: UnaSettings = {
+  const defaultSettings: Omit<UnaSettings, 'themes'> = {
     primaryColors: una.primary ? getPrimaryColors(una.primary) : {},
     grayColors: una.gray ? getGrayColors(una.gray) : {},
     primary: una.primary,
@@ -23,10 +23,9 @@ export function useUnaSettings(): UseUnaSettingsReturn {
     radius: una.radius,
     fontSize: una.fontSize,
     theme: una.theme,
-    themes: una.themes,
   } as const
 
-  const settings = useStorage<UnaSettings>('una-settings', defaultSettings, undefined, {
+  const settings = useStorage<Omit<UnaSettings, 'themes'>>('una-settings', defaultSettings, undefined, {
     mergeDefaults: defu,
   })
 

--- a/packages/nuxt/src/runtime/plugins/theme.client.ts
+++ b/packages/nuxt/src/runtime/plugins/theme.client.ts
@@ -1,10 +1,11 @@
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin, useAppConfig } from '#app'
 import { computed, watchEffect } from 'vue'
 import { useUnaSettings } from '../composables/useUnaSettings'
 
 let unaUIStyle: HTMLStyleElement
 
 export default defineNuxtPlugin(() => {
+  const { una: { themes } } = useAppConfig()
   const { settings } = useUnaSettings()
 
   unaUIStyle = document.createElement('style')
@@ -17,7 +18,7 @@ export default defineNuxtPlugin(() => {
 
   // created a computed property for styles
   const computedStyles = computed(() => {
-    const theme = settings.value.themes.find(t => t.name === settings.value.theme)
+    const theme = themes.find(t => t.name === settings.value.theme)
     if (settings.value.theme && theme) {
       return `
       :root {

--- a/packages/nuxt/src/runtime/plugins/theme.server.ts
+++ b/packages/nuxt/src/runtime/plugins/theme.server.ts
@@ -1,14 +1,16 @@
-import { defineNuxtPlugin, useHead } from '#app'
+import { defineNuxtPlugin, useAppConfig, useHead } from '#app'
 
 import { useUnaSettings } from '../composables/useUnaSettings'
 
 export default defineNuxtPlugin(() => {
+  const { una: { themes } } = useAppConfig()
   const { defaultSettings } = useUnaSettings()
   useHead({
     script: [
       {
         innerHTML: `
         ;(function() {
+          const themes = ${JSON.stringify(themes)}
           let settings = JSON.parse(localStorage.getItem('una-settings'))
 
           if (!settings) {
@@ -19,7 +21,7 @@ export default defineNuxtPlugin(() => {
           ${process.dev ? 'console.log({ settings })' : ''}
 
           if (settings.theme) {
-            const theme = settings.themes.find(t => t.name === settings.theme)  
+            const theme = themes.find(t => t.name === settings.theme)
             if (theme) {
               Object.entries(theme.cssVars.light).map(i => html.style.setProperty(i[0], i[1]))
               Object.entries(theme.cssVars.dark).map(i => html.style.setProperty(i[0], i[1]))


### PR DESCRIPTION
Preventing `themes` from being stored locally prevents a memory leak each time the settings are read.

Caveat: Themes are now written to the html, increasing the generated site size depending on how many themes are defined. Possible solution could be storing each theme in a separate js entrypoint, and conditionally load it.

Fixes #519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures consistent theme selection and application across client and server.

- Refactor
  - Themes are now sourced from app configuration rather than user settings for more reliable theming.
  - User settings no longer include the themes field, simplifying the settings shape.

- Chores
  - Updated internal typing to align with the streamlined settings structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->