### PR TITLE
feat(MessageScroller): expose scroll methods on the root component

### DIFF
--- a/packages/nuxt/src/runtime/components/message-scroller/MessageScroller.vue
+++ b/packages/nuxt/src/runtime/components/message-scroller/MessageScroller.vue
@@ -5,7 +5,16 @@ import { useMessageScrollerContext } from './useMessageScroller'
 
 const props = defineProps<NMessageScrollerProps>()
 
-const { autoscrolling, scrollableAttr } = useMessageScrollerContext()
+const { autoscrolling, scrollableAttr, scrollToEnd, scrollToMessage, scrollToStart } = useMessageScrollerContext()
+
+/**
+ * Exposed for controls the provider cannot reach by injection — a composer or
+ * toolbar rendered as a SIBLING of this subtree, or in the setup scope that
+ * renders `NMessageScrollerProvider`, cannot inject a context provided below it.
+ * Those reach the transcript through a template ref instead of
+ * `useMessageScroller()`.
+ */
+defineExpose({ scrollToEnd, scrollToMessage, scrollToStart })
 </script>
 
 <template>


### PR DESCRIPTION
Part of the [MessageScroller port map](https://github.com/una-ui/una-ui/issues/613). No ticket — surfacing an existing context member, not new engine behaviour.

`NMessageScrollerProvider` calls `provideMessageScroller()` in its own setup, so the context lands *below* the provider. Only descendants can reach it through `useMessageScroller()`:

```vue
<NMessageScrollerProvider>
  <NMessageScroller>…</NMessageScroller>   <!-- can inject -->
</NMessageScrollerProvider>
<MyComposer />                              <!-- sibling: cannot inject -->
```

A composer or toolbar rendered as a sibling of the transcript — or the setup scope that renders the provider in the first place — has no way in. Today the only workaround is to wrap that control in a throwaway component and push it inside the subtree.

`NMessageScroller` now exposes `scrollToEnd`, `scrollToMessage` and `scrollToStart`, so those callers can drive the transcript through a template ref:

```vue
<script setup lang="ts">
const scroller = ref<InstanceType<typeof NMessageScroller>>()
function send() {
  // …append the message
  scroller.value?.scrollToEnd({ behavior: 'smooth' })
}
</script>
```

The context already carries all three and `useMessageScroller()` already returns exactly this triple; this only surfaces them on the instance. No engine change, no behaviour change for existing consumers.

## Divergence from the source

The upstream shadcn-vue `MessageScroller.vue` has no `defineExpose` — this is a public-surface addition, the third intentional divergence from the port after the two behavioural ones in #623. Worth recording on the map's decision log.

## Known gaps

Filed here rather than silently shipped — say the word and I'll fold them into this PR:

- No `## Expose` section in `docs/content/3.components/message-scroller.md`. `input.md`, `combobox.md` and `stepper.md` all carry one for their exposed members.
- `message-scroller.md:125` still says the scroll commands must be called "from a component **rendered inside** `NMessageScrollerProvider`" — true for the composables, no longer the only route.
- The divergence comment explains *why* but doesn't carry the `Deliberate divergence from the shadcn-vue source … keep it when diffing against upstream` marking that `useMessageScroller.ts:778` and `:893` use.
- Nothing in the playground or examples exercises the template-ref route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
