### PR TITLE
docs(MessageScroller): document the exposed scroll methods

### DIFF
--- a/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerExpose.vue
+++ b/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerExpose.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+// This composer is rendered by the same component that renders the provider, so
+// it sits outside the context and cannot call useMessageScroller(). It drives
+// the transcript through a template ref on NMessageScroller instead.
+const scroller = useTemplateRef('scroller')
+
+const messages = ref([
+  { id: 'm1', role: 'user', text: 'Can a composer outside the provider still scroll the transcript?' },
+  { id: 'm2', role: 'assistant', text: 'Yes — through a template ref. The provider puts the context below itself, so anything rendered as a sibling of the transcript has nothing to inject, and this composer is rendered by the same component that renders the provider.' },
+  { id: 'm3', role: 'user', text: 'What does the ref give me?' },
+  { id: 'm4', role: 'assistant', text: 'The same three commands useMessageScroller() returns — scrollToEnd, scrollToStart and scrollToMessage. NMessageScroller exposes them on its instance, so the context is not the only way in.' },
+  { id: 'm5', role: 'user', text: 'And the send button?' },
+  { id: 'm6', role: 'assistant', text: 'Append the message, await nextTick() so the new item is in the DOM, then call scrollToEnd. Without the tick you would scroll to where the end used to be.' },
+  { id: 'm7', role: 'user', text: 'Does Top work the same way?' },
+  { id: 'm8', role: 'assistant', text: 'It calls scrollToStart off the same ref. Send a few messages, then jump back up here to see both ends of the transcript move.' },
+])
+
+const draft = ref('')
+
+async function send() {
+  const text = draft.value.trim()
+  if (!text)
+    return
+
+  messages.value.push({ id: `m${messages.value.length + 1}`, role: 'user', text })
+  draft.value = ''
+
+  // The append has to be in the DOM before the new end can be scrolled to.
+  await nextTick()
+  scroller.value?.scrollToEnd({ behavior: 'smooth' })
+}
+</script>
+
+<template>
+  <div class="w-full flex flex-col gap-3">
+    <div class="h-80 border rounded-lg bg-background">
+      <NMessageScrollerProvider>
+        <NMessageScroller ref="scroller">
+          <NMessageScrollerViewport>
+            <NMessageScrollerContent class="p-4">
+              <NMessageScrollerItem
+                v-for="message in messages"
+                :key="message.id"
+                :message-id="message.id"
+              >
+                <div
+                  class="max-w-[80%] rounded-lg px-3 py-2 text-sm"
+                  :class="message.role === 'user'
+                    ? 'ml-auto bg-primary text-primary-foreground'
+                    : 'bg-muted text-foreground'"
+                >
+                  {{ message.text }}
+                </div>
+              </NMessageScrollerItem>
+            </NMessageScrollerContent>
+          </NMessageScrollerViewport>
+
+          <NMessageScrollerButton />
+        </NMessageScroller>
+      </NMessageScrollerProvider>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <NInput
+        v-model="draft"
+        placeholder="Write a message, then send"
+        :una="{ inputWrapper: 'flex-1' }"
+        @keydown.enter="send"
+      />
+      <NButton
+        btn="outline-gray"
+        size="sm"
+        label="Send"
+        @click="send"
+      />
+      <NButton
+        btn="outline-gray"
+        size="sm"
+        label="Top"
+        @click="scroller?.scrollToStart({ behavior: 'smooth' })"
+      />
+    </div>
+  </div>
+</template>

--- a/docs/content/3.components/message-scroller.md
+++ b/docs/content/3.components/message-scroller.md
@@ -122,7 +122,7 @@ Prefer an opaque variant. The button floats over the transcript, so translucent 
 
 ### Jumping to messages
 
-Inside the provider, `useMessageScroller()` exposes the scroll commands and `useMessageScrollerVisibility()` reports which messages are on screen and which turn the reader is in. Both read the provider's context, so call them from a component **rendered inside** `NMessageScrollerProvider`.
+Inside the provider, `useMessageScroller()` exposes the scroll commands and `useMessageScrollerVisibility()` reports which messages are on screen and which turn the reader is in. Both read the provider's context, so call them from a component **rendered inside** `NMessageScrollerProvider`. A control that sits outside that subtree reaches the scroll commands through a template ref instead — see [Expose](#expose).
 
 | Composable                       | Returns                                                                             |
 | -------------------------------- | ----------------------------------------------------------------------------------- |
@@ -154,6 +154,27 @@ The viewport ships with the [`scroll-fade`](/utilities/scroll-fade) and scrollba
   :una="{ messageScrollerViewport: 'no-scrollbar' }"
 />
 ```
+
+## Expose
+
+`useMessageScroller()` only reaches the context from **inside** the provider. A composer or toolbar rendered as a sibling of the transcript — or the component that renders `NMessageScrollerProvider` in the first place — has nothing to inject, so `NMessageScroller` exposes the same three commands on its instance.
+
+| Name              | Type                                                               | Description                                                      |
+| ----------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| `scrollToEnd`     | `(options?: { behavior?: ScrollBehavior }) => boolean`             | Jumps to the live edge and resumes following it if `autoScroll`. |
+| `scrollToStart`   | `(options?: { behavior?: ScrollBehavior }) => boolean`             | Jumps to the top of the transcript.                              |
+| `scrollToMessage` | `(id: string, options?: NMessageScrollerScrollOptions) => boolean` | Jumps to a message by its `messageId`.                           |
+
+Each returns `false` when the viewport is not mounted yet. `scrollToMessage` queues the jump when the message has not registered yet, so it is safe to call before the item renders — `scrollToEnd` is immediate, so `await nextTick()` after appending a message.
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueMessageScrollerExpose
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/message-scroller/ExampleVueMessageScrollerExpose.vue
+::
+:::
 
 ## Props
 


### PR DESCRIPTION
Follow-up to [#645](https://github.com/una-ui/una-ui/pull/645), which exposed `scrollToEnd`, `scrollToMessage` and `scrollToStart` on `NMessageScroller` but shipped no docs — the page still read as if `useMessageScroller()` were the only route to the scroll commands.

## `## Expose` section

Same shape the other components with `defineExpose` use — [`input.md`](https://github.com/una-ui/una-ui/blob/v1.0.0/docs/content/3.components/input.md), [`combobox.md`](https://github.com/una-ui/una-ui/blob/v1.0.0/docs/content/3.components/combobox.md), [`stepper.md`](https://github.com/una-ui/una-ui/blob/v1.0.0/docs/content/3.components/stepper.md) — a Name/Type/Description table plus a runnable example.

The table also records the two behaviours a caller has to know and cannot see from the signature: every command returns `false` when the viewport is not mounted, and `scrollToMessage` queues the jump for a message that has not registered yet while `scrollToEnd` is immediate — so an append needs `await nextTick()` before it.

## Example

`ExampleVueMessageScrollerExpose.vue` renders the composer from the *same component that renders the provider*, which is exactly the case injection cannot serve — `useMessageScroller()` would throw there. Send appends a message, awaits the tick, then calls `scrollToEnd` off the ref; Top calls `scrollToStart`.

## "Jumping to messages"

That section's "call them from a component **rendered inside** `NMessageScrollerProvider`" is still true of the composables, but it was the page's only word on reaching the scroll commands. It now points at Expose for controls outside the subtree.

## Verified

Ran against the docs dev server on the built page, not just eyeballed:

- Send from `scrollTop: 0` → `414` (`scrollHeight - clientHeight`), message appended, draft cleared.
- Top → `scrollTop: 0`.
- No new console errors. (The hydration mismatch on this page predates this branch — `/components/input` shows the same.)

House style: `NInput` takes no `input=` variant here (it is incidental, as in `card`/`dialog`/`kbd`), and is sized through `:una="{ inputWrapper: 'flex-1' }"` — `class` lands on the inner `<input>`, since `NInput` sets `inheritAttrs: false`. Buttons match the family's `btn="outline-gray" size="sm"`.

## Still open from the #645 review

Not in this PR, say the word and I'll take them:

- The `defineExpose` comment in `MessageScroller.vue` doesn't carry the `Deliberate divergence from the shadcn-vue source … keep it when diffing against upstream` marking that `useMessageScroller.ts:778` and `:893` use — upstream has no `defineExpose`, so this is the third intentional divergence from the port.
- [#613](https://github.com/una-ui/una-ui/issues/613)'s decision log has no entry for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
