### PR TITLE
chore(MessageScroller): mark the expose as an upstream divergence

### DIFF
--- a/packages/nuxt/src/runtime/components/message-scroller/MessageScroller.vue
+++ b/packages/nuxt/src/runtime/components/message-scroller/MessageScroller.vue
@@ -9,10 +9,11 @@ const { autoscrolling, scrollableAttr, scrollToEnd, scrollToMessage, scrollToSta
 
 /**
  * Exposed for controls the provider cannot reach by injection — a composer or
- * toolbar rendered as a SIBLING of this subtree, or in the setup scope that
+ * toolbar rendered as a sibling of this subtree, or in the setup scope that
  * renders `NMessageScrollerProvider`, cannot inject a context provided below it.
- * Those reach the transcript through a template ref instead of
- * `useMessageScroller()`.
+ *
+ * Deliberate divergence from the shadcn-vue source, which exposes nothing here
+ * — keep it when diffing against upstream. See #645.
  */
 defineExpose({ scrollToEnd, scrollToMessage, scrollToStart })
 </script>


### PR DESCRIPTION
Follow-up to [#645](https://github.com/una-ui/una-ui/pull/645). Comment-only — no behaviour change.

`grep -rn defineExpose` over the shadcn-vue source finds nothing in the message-scroller family, so #645's expose is the **third** intentional divergence from the port and the first on public surface rather than behaviour.

[#613](https://github.com/una-ui/una-ui/issues/613) sets the bar for these:

> both are marked as such in the engine at their call sites so a future upstream diff does not read them as porting mistakes

The two engine divergences from [#622](https://github.com/una-ui/una-ui/issues/622) carry it — [`useMessageScroller.ts:778`](https://github.com/una-ui/una-ui/blob/v1.0.0/packages/nuxt/src/runtime/components/message-scroller/useMessageScroller.ts#L778) and [`:893`](https://github.com/una-ui/una-ui/blob/v1.0.0/packages/nuxt/src/runtime/components/message-scroller/useMessageScroller.ts#L893):

> Deliberate divergence from the shadcn-vue source, which has no re-entry here at all — keep it when diffing against upstream. See #622.

#645's comment explained *why the expose exists* but never said it diverges, which is the half a future upstream diff actually trips over. Same wording now, pointing at #645.

Two smaller things in the same comment:

- Dropped the "Those reach the transcript through a template ref instead of `useMessageScroller()`" line — that is audience-facing guidance and [#646](https://github.com/una-ui/una-ui/pull/646) puts it in the docs `## Expose` section, where a consumer will actually find it.
- `SIBLING` → `sibling`. It was the only all-caps emphasis in `packages/nuxt/src/runtime`.

Left alone deliberately: `defineExpose({ scrollToEnd, scrollToMessage, scrollToStart })` does repeat the triple that `useMessageScroller()` already selects, and `defineExpose({ ...useMessageScroller() })` would keep the two surfaces identical by construction. Not worth it — a spread hides the public surface from anyone scanning the file, and the names are the thing a reader is looking for here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
