### PR TITLE
feat(Table)!: add an opt-in pagination bar shaped after shadcn, with a table context

### DIFF
--- a/docs/components/content/examples/vue/table/ExampleVueTablePagination.vue
+++ b/docs/components/content/examples/vue/table/ExampleVueTablePagination.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ColumnDef, Table } from '@tanstack/vue-table'
+import type { ColumnDef } from '@tanstack/vue-table'
 import type { Person } from './makeData'
 import makeData from './makeData'
 
@@ -36,38 +36,13 @@ const pagination = ref({
   pageSize: 5,
   pageIndex: 0,
 })
-
-const table = useTemplateRef<Table<Person>>('table')
 </script>
 
 <template>
-  <div class="flex flex-col space-y-4">
-    <!-- table -->
-    <NTable
-      ref="table"
-      :pagination="pagination"
-      :columns
-      :data
-    />
-
-    <!-- pagination -->
-    <div
-      class="flex flex-wrap items-center justify-between gap-4 overflow-auto px-2"
-    >
-      <div
-        class="flex items-center justify-center text-sm font-medium"
-      >
-        Page {{ (table?.getState().pagination.pageIndex ?? 0) + 1 }} of
-        {{ table?.getPageCount().toLocaleString() }}
-      </div>
-
-      <NPagination
-        :page="(table?.getState().pagination.pageIndex ?? 0) + 1"
-        :total="table?.getFilteredRowModel().rows.length"
-        show-edges
-        :items-per-page="table?.getState().pagination.pageSize ?? 5"
-        @update:page="table?.setPageIndex($event - 1)"
-      />
-    </div>
-  </div>
+  <NTable
+    v-model:pagination="pagination"
+    :columns
+    :data
+    show-pagination
+  />
 </template>

--- a/docs/content/3.components/table.md
+++ b/docs/content/3.components/table.md
@@ -118,9 +118,11 @@ Loading allows you to show a loading progress indicator in the table. This is us
 
 ### Pagination
 
-`NTable` owns the pagination state and, with `show-pagination`, renders a bar
-for it inside the root, below the table: page meta, a rows-per-page control and
-the page navigation, wired to the table for you. Configure the bar through
+`NTable` owns the pagination state and, with `show-pagination`, renders
+shadcn's pagination bar below the table: the selection count (or row range) on
+the left, then rows per page, `Page X of Y` and the navigation on the right.
+Page numbers are off by default, as in shadcn; turn them on with
+`_tablePagination: { showListItem: true }`. Configure the bar through
 `_tablePagination`, which takes `NPagination`'s props, or replace it entirely
 with the `pagination` slot.
 

--- a/docs/content/3.components/table.md
+++ b/docs/content/3.components/table.md
@@ -118,12 +118,24 @@ Loading allows you to show a loading progress indicator in the table. This is us
 
 ### Pagination
 
-Pagination allows you to paginate rows in the table. This is useful when you want to paginate rows in the table.
+`NTable` owns the pagination state and, with `show-pagination`, renders a bar
+for it inside the root, below the table: page meta, a rows-per-page control and
+the page navigation, wired to the table for you. Configure the bar through
+`_tablePagination`, which takes `NPagination`'s props, or replace it entirely
+with the `pagination` slot.
 
 | Prop               | Default                        | Type                                    | Description                                                 |
 | ------------------ | ------------------------------ | --------------------------------------- | ----------------------------------------------------------- |
 | `pagination`       | `{pageIndex: 0, pageSize: 10}` | `{pageIndex: Number, pageSize: Number}` | Pagination state, can be binded with `v-model`.             |
 | `manualPagination` | `false`                        | `boolean`                               | Enable manual pagination, ideal for server-side pagination. |
+| `showPagination`   | `false`                        | `boolean`                               | Render the built-in pagination bar.                         |
+| `_tablePagination` | `{}`                           | `object`                                | Props for the bar's inner `NPagination`.                    |
+
+With `manualPagination`, pass `rowCount` so the bar knows the full size — the
+table only ever holds the current page. When row selection is on, the bar's
+start region shows the selection count instead of the row range. To compose the
+bar yourself outside the root, `NTablePagination` also takes the table instance
+directly as a `table` prop.
 
 :::CodeGroup
 ::div{label="Preview"}
@@ -379,6 +391,7 @@ Configure the progress using the `una` prop and utility classes.
 | `_tableSelectionHeader` | `{}`    | `object` | Props for the select-all checkbox.             |
 | `_tableSelectionCell`   | `{}`    | `object` | Props for the per-row selection checkbox.      |
 | `_tableExpandButton`    | `{}`    | `object` | Props for the row expand toggle.               |
+| `_tablePagination`      | `{}`    | `object` | Props for the built-in pagination bar.         |
 
 Each of the five widgets `NTable` renders on your behalf is a component in its
 own right — `NTableSortButton`, `NTableColumnFilter`, `NTableSelectionHeader`,
@@ -426,22 +439,23 @@ else you store there stays out of the DOM.
 
 ## Slots
 
-| Name              | Props    | Description                                                  |
-| ----------------- | -------- | ------------------------------------------------------------ |
-| `{column}-filter` | `column` | Column filter slot.                                          |
-| `{column}-header` | `column` | Column header slot.                                          |
-| `{column}-cell`   | `cell`   | Column cell slot.                                            |
-| `{column}-footer` | `column` | Column footer slot.                                          |
-| `header`          | `table`  | Header slot.                                                 |
-| `body`            | `table`  | Body slot.                                                   |
-| `row`             | `row`    | Row slot.                                                    |
-| `footer`          | `table`  | Footer slot.                                                 |
-| `select-header`   | `column` | Select-all checkbox slot, when `enableRowSelection` is set.  |
-| `select-cell`     | `cell`   | Per-row selection checkbox slot.                             |
-| `expand-cell`     | `cell`   | Row expand toggle slot, when an `expanded` slot is provided. |
-| `expanded`        | `row`    | Expanded row content slot.                                   |
-| `empty`           | -        | Empty slot.                                                  |
-| `loading`         | -        | Loading slot.                                                |
+| Name              | Props                 | Description                                                  |
+| ----------------- | --------------------- | ------------------------------------------------------------ |
+| `{column}-filter` | `column`              | Column filter slot.                                          |
+| `{column}-header` | `column`              | Column header slot.                                          |
+| `{column}-cell`   | `cell`                | Column cell slot.                                            |
+| `{column}-footer` | `column`              | Column footer slot.                                          |
+| `header`          | `table`               | Header slot.                                                 |
+| `body`            | `table`               | Body slot.                                                   |
+| `row`             | `row`                 | Row slot.                                                    |
+| `footer`          | `table`               | Footer slot.                                                 |
+| `select-header`   | `column`              | Select-all checkbox slot, when `enableRowSelection` is set.  |
+| `select-cell`     | `cell`                | Per-row selection checkbox slot.                             |
+| `expand-cell`     | `cell`                | Row expand toggle slot, when an `expanded` slot is provided. |
+| `expanded`        | `row`                 | Expanded row content slot.                                   |
+| `empty`           | -                     | Empty slot.                                                  |
+| `loading`         | -                     | Loading slot.                                                |
+| `pagination`      | `table`, `pagination` | Replaces the built-in pagination bar.                        |
 
 ::alert{type="warning"}
 `select-header`, `select-cell` and `expand-cell` are keyed off the reserved

--- a/packages/nuxt/playground/pages/components/table-pagination.vue
+++ b/packages/nuxt/playground/pages/components/table-pagination.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import type { ColumnDef, Table } from '@tanstack/vue-table'
+
+interface Row { id: number, name: string, email: string, status: string, amount: number }
+
+const rows: Row[] = Array.from({ length: 48 }, (_, i) => ({
+  id: i + 1,
+  name: `Person ${i + 1}`,
+  email: `person${i + 1}@example.com`,
+  status: ['active', 'pending', 'archived'][i % 3],
+  amount: (i + 1) * 37,
+}))
+
+const columns: ColumnDef<Row>[] = [
+  { header: 'Name', accessorKey: 'name' },
+  { header: 'Email', accessorKey: 'email' },
+  { header: 'Status', accessorKey: 'status' },
+  { header: 'Amount', accessorKey: 'amount' },
+]
+
+const data = ref(rows)
+const emptyData = ref<Row[]>([])
+
+const pDefault = ref({ pageIndex: 0, pageSize: 10 })
+const pSelect = ref({ pageIndex: 0, pageSize: 10 })
+const pOverride = ref({ pageIndex: 2, pageSize: 5 })
+const pSlot = ref({ pageIndex: 0, pageSize: 10 })
+const pStandalone = ref({ pageIndex: 0, pageSize: 10 })
+
+// server-side: the table only ever holds the current page, and reports the
+// full size through `rowCount`
+const pServer = ref({ pageIndex: 0, pageSize: 10 })
+const serverPage = computed(() => rows.slice(
+  pServer.value.pageIndex * pServer.value.pageSize,
+  (pServer.value.pageIndex + 1) * pServer.value.pageSize,
+))
+
+const standaloneTable = useTemplateRef<Table<Row>>('standaloneTable')
+</script>
+
+<template>
+  <div class="p-6 space-y-12">
+    <section class="space-y-2">
+      <h2 class="font-medium">
+        Default — <code>show-pagination</code>
+      </h2>
+      <NTable
+        id="t-default"
+        v-model:pagination="pDefault"
+        :columns
+        :data
+        show-pagination
+      />
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-medium">
+        Row selection on — start region shows the selection count
+      </h2>
+      <NTable
+        id="t-select"
+        v-model:pagination="pSelect"
+        :columns
+        :data
+        enable-row-selection
+        show-pagination
+      />
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-medium">
+        <code>_table-pagination</code> overrides — page format, no rows-per-page, no edges
+      </h2>
+      <NTable
+        id="t-override"
+        v-model:pagination="pOverride"
+        :columns
+        :data
+        show-pagination
+        :_table-pagination="{ showRowsPerPage: false, showEdges: false, _paginationInfo: { format: 'page' } }"
+      />
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-medium">
+        <code>#pagination</code> slot replaces the whole bar
+      </h2>
+      <NTable
+        id="t-slot"
+        v-model:pagination="pSlot"
+        :columns
+        :data
+        show-pagination
+      >
+        <template #pagination="{ pagination }">
+          <div class="flex items-center justify-between border-t border-border px-4 py-3 text-sm">
+            <span id="t-slot-text">custom bar — page index {{ pagination.pageIndex }}</span>
+            <NButton size="xs" btn="outline-gray" label="next" @click="pSlot.pageIndex++" />
+          </div>
+        </template>
+      </NTable>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-medium">
+        Server-side — <code>manual-pagination</code> + <code>row-count</code>
+      </h2>
+      <NTable
+        id="t-server"
+        v-model:pagination="pServer"
+        :columns
+        :data="serverPage"
+        manual-pagination
+        :row-count="rows.length"
+        show-pagination
+      />
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-medium">
+        Standalone — shadcn shape, <code>NTablePagination :table</code> outside the root
+      </h2>
+      <NTable
+        ref="standaloneTable"
+        v-model:pagination="pStandalone"
+        :columns
+        :data
+      />
+      <NTablePagination
+        v-if="standaloneTable"
+        id="t-standalone-bar"
+        class="mt-4 border-0 px-0"
+        :table="standaloneTable"
+      />
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-medium">
+        Empty and loading
+      </h2>
+      <NTable id="t-empty" :columns :data="emptyData" show-pagination />
+      <NTable id="t-loading" class="mt-6" :columns :data loading show-pagination />
+    </section>
+  </div>
+</template>

--- a/packages/nuxt/playground/pages/components/table-pagination.vue
+++ b/packages/nuxt/playground/pages/components/table-pagination.vue
@@ -40,12 +40,11 @@ const standaloneTable = useTemplateRef<Table<Row>>('standaloneTable')
 
 <template>
   <div class="p-6 space-y-12">
-    <section class="space-y-2">
+    <section id="t-default" class="space-y-2">
       <h2 class="font-medium">
         Default — <code>show-pagination</code>
       </h2>
       <NTable
-        id="t-default"
         v-model:pagination="pDefault"
         :columns
         :data
@@ -53,12 +52,11 @@ const standaloneTable = useTemplateRef<Table<Row>>('standaloneTable')
       />
     </section>
 
-    <section class="space-y-2">
+    <section id="t-select" class="space-y-2">
       <h2 class="font-medium">
         Row selection on — start region shows the selection count
       </h2>
       <NTable
-        id="t-select"
         v-model:pagination="pSelect"
         :columns
         :data
@@ -67,12 +65,11 @@ const standaloneTable = useTemplateRef<Table<Row>>('standaloneTable')
       />
     </section>
 
-    <section class="space-y-2">
+    <section id="t-override" class="space-y-2">
       <h2 class="font-medium">
         <code>_table-pagination</code> overrides — page format, no rows-per-page, no edges
       </h2>
       <NTable
-        id="t-override"
         v-model:pagination="pOverride"
         :columns
         :data
@@ -81,12 +78,11 @@ const standaloneTable = useTemplateRef<Table<Row>>('standaloneTable')
       />
     </section>
 
-    <section class="space-y-2">
+    <section id="t-slot" class="space-y-2">
       <h2 class="font-medium">
         <code>#pagination</code> slot replaces the whole bar
       </h2>
       <NTable
-        id="t-slot"
         v-model:pagination="pSlot"
         :columns
         :data
@@ -101,12 +97,11 @@ const standaloneTable = useTemplateRef<Table<Row>>('standaloneTable')
       </NTable>
     </section>
 
-    <section class="space-y-2">
+    <section id="t-server" class="space-y-2">
       <h2 class="font-medium">
         Server-side — <code>manual-pagination</code> + <code>row-count</code>
       </h2>
       <NTable
-        id="t-server"
         v-model:pagination="pServer"
         :columns
         :data="serverPage"
@@ -116,7 +111,7 @@ const standaloneTable = useTemplateRef<Table<Row>>('standaloneTable')
       />
     </section>
 
-    <section class="space-y-2">
+    <section id="t-standalone" class="space-y-2">
       <h2 class="font-medium">
         Standalone — shadcn shape, <code>NTablePagination :table</code> outside the root
       </h2>
@@ -134,12 +129,12 @@ const standaloneTable = useTemplateRef<Table<Row>>('standaloneTable')
       />
     </section>
 
-    <section class="space-y-2">
+    <section id="t-degenerate" class="space-y-2">
       <h2 class="font-medium">
         Empty and loading
       </h2>
-      <NTable id="t-empty" :columns :data="emptyData" show-pagination />
-      <NTable id="t-loading" class="mt-6" :columns :data loading show-pagination />
+      <NTable :columns :data="emptyData" show-pagination />
+      <NTable class="mt-6" :columns :data loading show-pagination />
     </section>
   </div>
 </template>

--- a/packages/nuxt/src/runtime/components/data/table/Table.vue
+++ b/packages/nuxt/src/runtime/components/data/table/Table.vue
@@ -38,14 +38,17 @@ import TableFooter from './TableFooter.vue'
 import TableHead from './TableHead.vue'
 import TableHeader from './TableHeader.vue'
 import TableLoading from './TableLoading.vue'
+import TablePagination from './TablePagination.vue'
 import TableRow from './TableRow.vue'
 import TableSelectionCell from './TableSelectionCell.vue'
 import TableSelectionHeader from './TableSelectionHeader.vue'
 import TableSortButton from './TableSortButton.vue'
+import { provideTableContext } from './useTable'
 
 const props = withDefaults(defineProps <NTableProps<TData, TValue>>(), {
   enableMultiRowSelection: true,
   enableSortingRemoval: true,
+  showPagination: false,
 })
 const emit = defineEmits<{
   select: [row: TData]
@@ -179,6 +182,15 @@ const table = useVueTable({
   onColumnPinningChange: updaterOrValue => valueUpdater(updaterOrValue, columnPinning),
   onExpandedChange: updaterOrValue => valueUpdater(updaterOrValue, expanded),
   onGroupingChange: updaterOrValue => valueUpdater(updaterOrValue, grouping),
+})
+
+// the seam the built-in pagination bar — and anything composed into
+// `#pagination` — reads the instance through, without a template ref
+provideTableContext({
+  table,
+  pagination: computed(() => pagination.value),
+  setPageIndex: index => table.setPageIndex(index),
+  setPageSize: size => table.setPageSize(size),
 })
 
 function getHeaderColumnFiltersCount(headers: Header<unknown, unknown>[]): number {
@@ -485,5 +497,18 @@ defineExpose({
         </TableFooter>
       </table>
     </ScrollArea>
+
+    <!-- pagination bar: inside the root, outside the scroll area -->
+    <slot
+      v-if="showPagination || $slots.pagination"
+      name="pagination"
+      :table="table"
+      :pagination="pagination"
+    >
+      <TablePagination
+        :una
+        v-bind="props._tablePagination"
+      />
+    </slot>
   </div>
 </template>

--- a/packages/nuxt/src/runtime/components/data/table/Table.vue
+++ b/packages/nuxt/src/runtime/components/data/table/Table.vue
@@ -45,6 +45,11 @@ import TableSelectionHeader from './TableSelectionHeader.vue'
 import TableSortButton from './TableSortButton.vue'
 import { provideTableContext } from './useTable'
 
+// the root is a fragment once the pagination bar renders beside `table-root`,
+// so attrs cannot be inherited — they keep going to `<table>` through the
+// explicit `v-bind="$attrs"` there, as they always have
+defineOptions({ inheritAttrs: false })
+
 const props = withDefaults(defineProps <NTableProps<TData, TValue>>(), {
   enableMultiRowSelection: true,
   enableSortingRemoval: true,
@@ -497,18 +502,19 @@ defineExpose({
         </TableFooter>
       </table>
     </ScrollArea>
-
-    <!-- pagination bar: inside the root, outside the scroll area -->
-    <slot
-      v-if="showPagination || $slots.pagination"
-      name="pagination"
-      :table="table"
-      :pagination="pagination"
-    >
-      <TablePagination
-        :una
-        v-bind="props._tablePagination"
-      />
-    </slot>
   </div>
+
+  <!-- pagination bar: a sibling below the root, where shadcn's
+       DataTablePagination sits relative to the bordered table -->
+  <slot
+    v-if="showPagination || $slots.pagination"
+    name="pagination"
+    :table="table"
+    :pagination="pagination"
+  >
+    <TablePagination
+      :una
+      v-bind="props._tablePagination"
+    />
+  </slot>
 </template>

--- a/packages/nuxt/src/runtime/components/data/table/TablePagination.vue
+++ b/packages/nuxt/src/runtime/components/data/table/TablePagination.vue
@@ -9,19 +9,26 @@ import PaginationInfo from '../../elements/pagination/PaginationInfo.vue'
 import PaginationRowsPerPage from '../../elements/pagination/PaginationRowsPerPage.vue'
 import { useTable } from './useTable'
 
+// shadcn's DataTablePagination, part for part: the selection count on the
+// left, then rows per page, "Page X of Y" and first/prev/next/last on the
+// right — and no page numbers, which is what keeps it on one row
 const props = withDefaults(defineProps<NTablePaginationProps>(), {
   showInfo: true,
   showRowsPerPage: true,
-  showEdges: true,
+  showListItem: false,
+  // shadcn's `size-8` navigation buttons
+  square: '8',
 })
 
 const context = useTable(null)
 
-// context when nested in `NTable`, the `table` prop when composed on its own —
+// context when rendered by `NTable`, the `table` prop when composed on its own —
 // the same pattern as `NPaginationInfo`, and shadcn's `<DataTablePagination :table />`
 const table = computed(() => props.table ?? context?.table)
 
-const delegatedProps = reactiveOmit(props, ['class', 'una', 'table'])
+// `showInfo`, `showRowsPerPage` and their prop bags are consumed here: the
+// inner `NPagination` renders the navigation only, never its own regions
+const delegatedProps = reactiveOmit(props, ['class', 'una', 'table', 'showInfo', 'showRowsPerPage', '_paginationInfo', '_paginationRowsPerPage'])
 
 // forward only what was actually passed: props typed as booleans are cast to
 // `false` when absent, and spreading those would override the wrapped
@@ -39,29 +46,45 @@ const total = computed(() => {
   const t = table.value
   if (!t)
     return 0
-  if (t.options.rowCount != null)
-    return t.options.rowCount
-  if (t.options.pageCount != null && t.options.pageCount >= 0)
-    return t.options.pageCount * itemsPerPage.value
+
+  const { rowCount, pageCount: count } = t.options
+  if (rowCount != null)
+    return rowCount
+  if (count != null && count >= 0)
+    return count * itemsPerPage.value
+
   return t.getFilteredRowModel().rows.length
+})
+
+const pageCount = computed(() => {
+  const n = table.value?.getPageCount() ?? 0
+  return n > 0 ? n : Math.max(1, Math.ceil(total.value / itemsPerPage.value))
 })
 
 const selectable = computed(() => Boolean(table.value?.options.enableRowSelection))
 const selectedCount = computed(() => table.value?.getFilteredSelectedRowModel().rows.length ?? 0)
-const rowCount = computed(() => table.value?.getFilteredRowModel().rows.length ?? 0)
+const filteredCount = computed(() => table.value?.getFilteredRowModel().rows.length ?? 0)
 
-function onPage(value: number) {
+const first = computed(() => total.value ? (page.value - 1) * itemsPerPage.value + 1 : 0)
+const last = computed(() => Math.min(page.value * itemsPerPage.value, total.value))
+
+// shadcn's left-hand text; the row range when there is nothing to select
+const status = computed(() => selectable.value
+  ? `${selectedCount.value} of ${filteredCount.value} row(s) selected.`
+  : `Showing ${first.value}–${last.value} of ${total.value}`)
+
+function onPage(n: number) {
   if (context)
-    context.setPageIndex(value - 1)
+    context.setPageIndex(n - 1)
   else
-    table.value?.setPageIndex(value - 1)
+    table.value?.setPageIndex(n - 1)
 }
 
-function onItemsPerPage(value: number) {
+function onItemsPerPage(n: number) {
   if (context)
-    context.setPageSize(value)
+    context.setPageSize(n)
   else
-    table.value?.setPageSize(value)
+    table.value?.setPageSize(n)
 }
 </script>
 
@@ -73,38 +96,65 @@ function onItemsPerPage(value: number) {
       props.class,
     )"
   >
-    <Pagination
-      v-bind="forwardedProps"
-      :page
-      :items-per-page="itemsPerPage"
-      :total
-      :una="props.una"
-      :_pagination-info="{ format: 'range', ...props._paginationInfo }"
-      @update:page="onPage"
-      @update:items-per-page="onItemsPerPage"
+    <div
+      v-if="showInfo"
+      :class="cn('table-pagination-status', props.una?.tablePaginationStatus)"
     >
-      <!-- with row selection on, the start region shows the selection count,
-           as shadcn's bar does; a consumer-provided #start still wins -->
-      <template v-if="selectable && !$slots.start" #start>
-        <PaginationInfo
-          v-if="showInfo"
-          :una
-          v-bind="props._paginationInfo"
-        >
-          {{ selectedCount }} of {{ rowCount }} row(s) selected
-        </PaginationInfo>
+      <slot
+        name="status"
+        :selected="selectedCount"
+        :filtered="filteredCount"
+        :total
+        :first
+        :last
+      >
+        {{ status }}
+      </slot>
+    </div>
 
+    <div :class="cn('table-pagination-controls', props.una?.tablePaginationControls)">
+      <div
+        v-if="showRowsPerPage"
+        :class="cn('table-pagination-page-size', props.una?.tablePaginationPageSize)"
+      >
         <PaginationRowsPerPage
-          v-if="showRowsPerPage"
+          label="Rows per page"
           :disabled="props.disabled"
+          :items-per-page="itemsPerPage"
           :una
-          v-bind="props._paginationRowsPerPage"
+          v-bind="{ _selectTrigger: { class: 'h-8' }, ...props._paginationRowsPerPage }"
+          @update:items-per-page="onItemsPerPage"
         />
-      </template>
+      </div>
 
-      <template v-for="(_, name) in $slots" #[name]="slotData">
-        <slot :name="name" v-bind="slotData" />
-      </template>
-    </Pagination>
+      <!-- literal weight/colour rather than in the shortcut: `pagination-info`
+           sets a muted colour in the same layer, and literals win regardless -->
+      <PaginationInfo
+        :page
+        :page-count="pageCount"
+        :una
+        :class="cn('table-pagination-page font-medium text-foreground', props.una?.tablePaginationPage)"
+        v-bind="props._paginationInfo"
+      />
+
+      <!-- `hidden lg:inline-flex` stays literal for the same reason: it has to
+           beat `.btn`'s own display, which lives in the shortcuts layer -->
+      <Pagination
+        v-bind="forwardedProps"
+        :page
+        :items-per-page="itemsPerPage"
+        :total
+        :una
+        :class="cn('table-pagination-nav', props.una?.tablePaginationNav)"
+        :_pagination-list="{ class: 'gap-2', ...props._paginationList }"
+        :_pagination-first="{ class: 'hidden lg:inline-flex', ...props._paginationFirst }"
+        :_pagination-last="{ class: 'hidden lg:inline-flex', ...props._paginationLast }"
+        @update:page="onPage"
+      >
+        <template v-for="(_, name) in $slots" #[name]="slotData">
+          <slot :name="name" v-bind="slotData" />
+        </template>
+      </Pagination>
+    </div>
   </div>
 </template>

--- a/packages/nuxt/src/runtime/components/data/table/TablePagination.vue
+++ b/packages/nuxt/src/runtime/components/data/table/TablePagination.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import type { NTablePaginationProps } from '../../../types'
+import { reactiveOmit } from '@vueuse/core'
+import { useForwardProps } from 'reka-ui'
+import { computed } from 'vue'
+import { cn } from '../../../utils'
+import Pagination from '../../elements/pagination/Pagination.vue'
+import PaginationInfo from '../../elements/pagination/PaginationInfo.vue'
+import PaginationRowsPerPage from '../../elements/pagination/PaginationRowsPerPage.vue'
+import { useTable } from './useTable'
+
+const props = withDefaults(defineProps<NTablePaginationProps>(), {
+  showInfo: true,
+  showRowsPerPage: true,
+  showEdges: true,
+})
+
+const context = useTable(null)
+
+// context when nested in `NTable`, the `table` prop when composed on its own —
+// the same pattern as `NPaginationInfo`, and shadcn's `<DataTablePagination :table />`
+const table = computed(() => props.table ?? context?.table)
+
+const delegatedProps = reactiveOmit(props, ['class', 'una', 'table'])
+
+// forward only what was actually passed: props typed as booleans are cast to
+// `false` when absent, and spreading those would override the wrapped
+// component's own defaults
+const forwardedProps = useForwardProps(delegatedProps)
+
+const pagination = computed(() => context?.pagination.value ?? table.value?.getState().pagination)
+const page = computed(() => (pagination.value?.pageIndex ?? 0) + 1)
+const itemsPerPage = computed(() => pagination.value?.pageSize ?? 10)
+
+// a server-side table reports its size through `rowCount`; one that only gives
+// `pageCount` can still get the page count right, at the cost of "of N"
+// rounding up to a multiple of the page size
+const total = computed(() => {
+  const t = table.value
+  if (!t)
+    return 0
+  if (t.options.rowCount != null)
+    return t.options.rowCount
+  if (t.options.pageCount != null && t.options.pageCount >= 0)
+    return t.options.pageCount * itemsPerPage.value
+  return t.getFilteredRowModel().rows.length
+})
+
+const selectable = computed(() => Boolean(table.value?.options.enableRowSelection))
+const selectedCount = computed(() => table.value?.getFilteredSelectedRowModel().rows.length ?? 0)
+const rowCount = computed(() => table.value?.getFilteredRowModel().rows.length ?? 0)
+
+function onPage(value: number) {
+  if (context)
+    context.setPageIndex(value - 1)
+  else
+    table.value?.setPageIndex(value - 1)
+}
+
+function onItemsPerPage(value: number) {
+  if (context)
+    context.setPageSize(value)
+  else
+    table.value?.setPageSize(value)
+}
+</script>
+
+<template>
+  <div
+    :class="cn(
+      'table-pagination',
+      props.una?.tablePagination,
+      props.class,
+    )"
+  >
+    <Pagination
+      v-bind="forwardedProps"
+      :page
+      :items-per-page="itemsPerPage"
+      :total
+      :una="props.una"
+      :_pagination-info="{ format: 'range', ...props._paginationInfo }"
+      @update:page="onPage"
+      @update:items-per-page="onItemsPerPage"
+    >
+      <!-- with row selection on, the start region shows the selection count,
+           as shadcn's bar does; a consumer-provided #start still wins -->
+      <template v-if="selectable && !$slots.start" #start>
+        <PaginationInfo
+          v-if="showInfo"
+          :una
+          v-bind="props._paginationInfo"
+        >
+          {{ selectedCount }} of {{ rowCount }} row(s) selected
+        </PaginationInfo>
+
+        <PaginationRowsPerPage
+          v-if="showRowsPerPage"
+          :disabled="props.disabled"
+          :una
+          v-bind="props._paginationRowsPerPage"
+        />
+      </template>
+
+      <template v-for="(_, name) in $slots" #[name]="slotData">
+        <slot :name="name" v-bind="slotData" />
+      </template>
+    </Pagination>
+  </div>
+</template>

--- a/packages/nuxt/src/runtime/components/data/table/useTable.ts
+++ b/packages/nuxt/src/runtime/components/data/table/useTable.ts
@@ -1,0 +1,19 @@
+import type { PaginationState, Table } from '@tanstack/vue-table'
+import type { ComputedRef } from 'vue'
+import { createContext } from 'reka-ui'
+
+/**
+ * `NTable`'s own context — the seam its built-in pagination bar reads through,
+ * so the bar and anything composed into `#pagination` reach the table instance
+ * without a template ref. `defineExpose({ ...table })` stays for consumers.
+ *
+ * Parts inject with a `null` fallback so they still work on their own, taking
+ * the table as a prop instead — the same nested-vs-standalone pattern as
+ * `NPaginationInfo`.
+ */
+export const [useTable, provideTableContext] = createContext<{
+  table: Table<any>
+  pagination: ComputedRef<PaginationState>
+  setPageIndex: (index: number) => void
+  setPageSize: (size: number) => void
+}>('Table')

--- a/packages/nuxt/src/runtime/types/table.ts
+++ b/packages/nuxt/src/runtime/types/table.ts
@@ -284,7 +284,7 @@ export interface NTablePaginationProps extends Omit<NPaginationProps, 'page' | '
    * `NTable`; pass it directly to use the bar on its own, outside the root.
    */
   table?: Table<any>
-  una?: Pick<NTableUnaProps, 'tablePagination'> & NPaginationProps['una']
+  una?: Pick<NTableUnaProps, 'tablePagination' | 'tablePaginationStatus' | 'tablePaginationControls' | 'tablePaginationPageSize' | 'tablePaginationPage' | 'tablePaginationNav'> & NPaginationProps['una']
 }
 
 export interface NTableUnaProps {
@@ -318,6 +318,11 @@ export interface NTableUnaProps {
   tableExpandIconBase?: HTMLAttributes['class']
   tableExpandIcon?: HTMLAttributes['class']
   tablePagination?: HTMLAttributes['class']
+  tablePaginationStatus?: HTMLAttributes['class']
+  tablePaginationControls?: HTMLAttributes['class']
+  tablePaginationPageSize?: HTMLAttributes['class']
+  tablePaginationPage?: HTMLAttributes['class']
+  tablePaginationNav?: HTMLAttributes['class']
 }
 
 /**

--- a/packages/nuxt/src/runtime/types/table.ts
+++ b/packages/nuxt/src/runtime/types/table.ts
@@ -14,6 +14,7 @@ import type { HTMLAttributes } from 'vue'
 import type { NButtonProps } from './button'
 import type { NCheckboxProps } from './checkbox'
 import type { NInputProps } from './input'
+import type { NPaginationProps } from './pagination'
 import type { NProgressProps } from './progress'
 import type { NScrollAreaProps, NScrollAreaUnaProps } from './scroll-area'
 
@@ -149,12 +150,21 @@ export interface NTableProps<TData, TValue> extends Omit<CoreOptions<TData>, 'da
   _tableSelectionHeader?: Omit<NTableSelectionHeaderProps<TData>, 'table'>
   _tableSelectionCell?: Omit<NTableSelectionCellProps<TData>, 'row'>
   _tableExpandButton?: Omit<NTableExpandButtonProps<TData>, 'row'>
+  _tablePagination?: Omit<NTablePaginationProps, 'table'>
   _scrollArea?: NScrollAreaProps
 
   /**
    * Whether the table is loading.
    */
   loading?: boolean
+  /**
+   * Render the built-in pagination bar inside the root, below the table.
+   * Configure it through `_tablePagination`, or replace it with the
+   * `pagination` slot.
+   *
+   * @default false
+   */
+  showPagination?: boolean
   /**
    * `UnaUI` preset configuration
    *
@@ -268,6 +278,15 @@ export interface NTableExpandButtonProps<TData = any> extends Omit<NButtonProps,
   una?: Pick<NTableUnaProps, 'tableExpandButton' | 'tableExpandIconBase' | 'tableExpandIcon'> & NButtonProps['una']
 }
 
+export interface NTablePaginationProps extends Omit<NPaginationProps, 'page' | 'defaultPage' | 'itemsPerPage' | 'total' | 'una'> {
+  /**
+   * The TanStack table instance. Supplied through context when rendered by
+   * `NTable`; pass it directly to use the bar on its own, outside the root.
+   */
+  table?: Table<any>
+  una?: Pick<NTableUnaProps, 'tablePagination'> & NPaginationProps['una']
+}
+
 export interface NTableUnaProps {
   table?: HTMLAttributes['class']
   tableRoot?: HTMLAttributes['class']
@@ -298,6 +317,7 @@ export interface NTableUnaProps {
   tableExpandButton?: HTMLAttributes['class']
   tableExpandIconBase?: HTMLAttributes['class']
   tableExpandIcon?: HTMLAttributes['class']
+  tablePagination?: HTMLAttributes['class']
 }
 
 /**

--- a/packages/nuxt/src/runtime/types/table.ts
+++ b/packages/nuxt/src/runtime/types/table.ts
@@ -158,9 +158,9 @@ export interface NTableProps<TData, TValue> extends Omit<CoreOptions<TData>, 'da
    */
   loading?: boolean
   /**
-   * Render the built-in pagination bar inside the root, below the table.
-   * Configure it through `_tablePagination`, or replace it with the
-   * `pagination` slot.
+   * Render the built-in pagination bar below the root, as a sibling rather
+   * than inside it. Configure it through `_tablePagination`, or replace it
+   * with the `pagination` slot.
    *
    * @default false
    */
@@ -278,12 +278,29 @@ export interface NTableExpandButtonProps<TData = any> extends Omit<NButtonProps,
   una?: Pick<NTableUnaProps, 'tableExpandButton' | 'tableExpandIconBase' | 'tableExpandIcon'> & NButtonProps['una']
 }
 
-export interface NTablePaginationProps extends Omit<NPaginationProps, 'page' | 'defaultPage' | 'itemsPerPage' | 'total' | 'una'> {
+export interface NTablePaginationProps extends Omit<NPaginationProps, 'page' | 'defaultPage' | 'itemsPerPage' | 'total' | 'una' | 'showInfo' | 'showRowsPerPage'> {
   /**
    * The TanStack table instance. Supplied through context when rendered by
    * `NTable`; pass it directly to use the bar on its own, outside the root.
    */
   table?: Table<any>
+  /**
+   * Render the status text on the left: the selection count when the table
+   * has row selection enabled, otherwise the visible row range.
+   *
+   * Unlike `NPagination`'s flag of the same name, this never toggles
+   * `NPaginationInfo` — the bar always renders "Page X of Y" among its
+   * controls.
+   *
+   * @default true
+   */
+  showInfo?: boolean
+  /**
+   * Render the rows-per-page select among the controls.
+   *
+   * @default true
+   */
+  showRowsPerPage?: boolean
   una?: Pick<NTableUnaProps, 'tablePagination' | 'tablePaginationStatus' | 'tablePaginationControls' | 'tablePaginationPageSize' | 'tablePaginationPage' | 'tablePaginationNav'> & NPaginationProps['una']
 }
 

--- a/packages/preset/src/_shortcuts/table.ts
+++ b/packages/preset/src/_shortcuts/table.ts
@@ -65,11 +65,9 @@ export const staticTable: Record<`${TablePrefix}-${string}` | TablePrefix, strin
   'table-expand-icon-base': 'transform transition-transform duration-200',
 
   // table-pagination
-  // the built-in bar sits inside `table-root` below the table, outside the
-  // scroll area, so it never scrolls with a wide table
-  // table-pagination — shadcn's DataTablePagination, part for part: status on
-  // the left, then rows per page, "Page X of Y" and the navigation on the
-  // right; a sibling below `table-root`, hence the `mt-4`
+  // shadcn's DataTablePagination, part for part: status on the left, then rows
+  // per page, "Page X of Y" and the navigation on the right; a sibling below
+  // `table-root`, hence the `mt-4`
   'table-pagination': 'mt-4 flex items-center justify-between px-4',
   'table-pagination-status': 'hidden flex-1 text-sm text-muted-foreground lg:flex',
   'table-pagination-controls': 'flex w-full items-center gap-8 lg:w-fit',

--- a/packages/preset/src/_shortcuts/table.ts
+++ b/packages/preset/src/_shortcuts/table.ts
@@ -64,6 +64,11 @@ export const staticTable: Record<`${TablePrefix}-${string}` | TablePrefix, strin
   'table-expand-button': '',
   'table-expand-icon-base': 'transform transition-transform duration-200',
 
+  // table-pagination
+  // the built-in bar sits inside `table-root` below the table, outside the
+  // scroll area, so it never scrolls with a wide table
+  'table-pagination': 'flex items-center border-t border-border px-4 py-3',
+
   // table-footer
   'table-footer': 'border-t border-border bg-muted font-medium [&>tr]:last:border-b-0',
 }

--- a/packages/preset/src/_shortcuts/table.ts
+++ b/packages/preset/src/_shortcuts/table.ts
@@ -67,7 +67,15 @@ export const staticTable: Record<`${TablePrefix}-${string}` | TablePrefix, strin
   // table-pagination
   // the built-in bar sits inside `table-root` below the table, outside the
   // scroll area, so it never scrolls with a wide table
-  'table-pagination': 'flex items-center border-t border-border px-4 py-3',
+  // table-pagination — shadcn's DataTablePagination, part for part: status on
+  // the left, then rows per page, "Page X of Y" and the navigation on the
+  // right; a sibling below `table-root`, hence the `mt-4`
+  'table-pagination': 'mt-4 flex items-center justify-between px-4',
+  'table-pagination-status': 'hidden flex-1 text-sm text-muted-foreground lg:flex',
+  'table-pagination-controls': 'flex w-full items-center gap-8 lg:w-fit',
+  'table-pagination-page-size': 'hidden items-center gap-2 lg:flex',
+  'table-pagination-page': 'flex w-fit items-center justify-center text-sm',
+  'table-pagination-nav': 'ml-auto flex items-center lg:ml-0',
 
   // table-footer
   'table-footer': 'border-t border-border bg-muted font-medium [&>tr]:last:border-b-0',

--- a/packages/preset/src/prefixes.ts
+++ b/packages/preset/src/prefixes.ts
@@ -230,6 +230,7 @@ export default [
   'table-head',
   'table-header',
   'table-loading',
+  'table-pagination',
   'table-row',
   'table-selection-cell',
   'table-selection-header',


### PR DESCRIPTION
Implements [#634](https://github.com/una-ui/una-ui/issues/634) from the [Table & Pagination configurability map](https://github.com/una-ui/una-ui/issues/627). Builds on the merged #638 and #639.

## Why

`NTable` owned the pagination state — `pagination` v-model, `getPaginationRowModel()` — but rendered no surface for it, so the docs example hand-rolled `Page X of Y` in userland markup. With the `NPagination` parts from #639 in place, the table can render a real bar.

## What it is — shadcn's `DataTablePagination`, part for part

```
[ 0 of 68 row(s) selected. ]        [ Rows per page [10 ▾] ]  [ Page 1 of 7 ]  [ « ‹ › » ]
```

- A **sibling below `table-root`** (`mt-4 px-4`), not inside it — exactly where shadcn places it relative to the bordered table.
- **Left:** `"n of m row(s) selected."`, or the row range when selection is off. `flex-1`, hidden below `lg`.
- **Right, `gap-8`:** `Rows per page` + select (hidden below `lg`), `Page X of Y`, then first/prev/next/last as 32px outline squares (`square="8"`), first/last hidden below `lg`.
- **No page numbers** — that is what keeps it on one row. `_tablePagination: { showListItem: true }` brings them back.

`NTablePagination` composes `NPaginationRowsPerPage`, `NPaginationInfo` and a list-less `NPagination` directly, consuming `showInfo` / `showRowsPerPage` itself and forwarding the rest of `NPaginationProps` to the navigation. One `una` key per part: `tablePagination`, `-Status`, `-Controls`, `-PageSize`, `-Page`, `-Nav`.

## Surface on `NTable`

`showPagination` (default `false`), `_tablePagination` (prop bag for the inner parts), a `#pagination` slot scoped `{ table, pagination }` that replaces the whole bar.

**State access:** `NTable` now provides a context — `{ table, pagination, setPageIndex, setPageSize }` — the same move `NPagination` made in #639, so the bar and anything composed into `#pagination` reach the instance without a template ref. Used on its own, `NTablePagination` takes the instance as a `table` prop, which reproduces shadcn's `<DataTablePagination :table />`. `defineExpose({ ...table })` is unchanged.

**Server-side:** under `manualPagination`, `total` comes from `rowCount`; a table that only gives `pageCount` derives `pageCount × pageSize`.

## Two things worth knowing

- **`NTable` renders a fragment when the bar shows**, with `inheritAttrs: false`. Non-prop attributes keep going to `<table>` through the explicit `v-bind="$attrs"` that was already there — they were previously *also* duplicated onto the wrapper (invalid duplicate `id`s), and no longer are.
- Two declarations stay **literal** in the template rather than in a shortcut: `hidden lg:inline-flex` on first/last must beat `.btn`'s display, and `font-medium text-foreground` on the page text must beat `pagination-info`'s muted colour. Both competitors live in the shortcuts layer, where relative order is not guaranteed; a literal utility always wins.

## Verification

Playground at 1557px: bar height **32px**, all four parts vertically centred on one line, 16px inset each side. Navigation (`Person 1 → 11`, "Page 2 of 5"), page size 20 → "Page 1 of 3" with 20 rows, selection count "0 → 1 of 48 row(s) selected.", server-side via `rowCount` with only 10 rows in the DOM, standalone via the `table` prop, the `#pagination` slot, empty ("Showing 0–0 of 0 · Page 1 of 1") and loading. No overflow. Below `lg`: status, page size and first/last hide; prev/next and "Page X of Y" remain.

Docs: the Pagination example uses the bar; `table.md` documents `show-pagination`, `_tablePagination` and the `pagination` slot.

`pnpm typecheck` clean · `eslint` clean · 54 tests pass.

Pre-existing, not from this PR: the playground's hydration id mismatches (`v-0-N`, server 13 ahead of the client on every checkbox and select) come from the playground layout's popover triggers and appear on unrelated pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
