### PR TITLE
fix(Table): read the table options reactively

### DIFF
--- a/packages/nuxt/src/runtime/components/data/table/Table.vue
+++ b/packages/nuxt/src/runtime/components/data/table/Table.vue
@@ -148,26 +148,71 @@ const table = useVueTable({
     get grouping() { return grouping.value },
   },
 
-  enableMultiRowSelection: props.enableMultiRowSelection,
-  enableSubRowSelection: props.enableSubRowSelection,
-  autoResetAll: props.autoResetAll,
-  enableRowSelection: props.enableRowSelection,
-  enableColumnFilters: props.enableColumnFilters,
-  manualPagination: props.manualPagination,
-  manualSorting: props.manualSorting,
-  manualFiltering: props.manualFiltering,
-  globalFilterFn: props.globalFilterFn,
-  filterFns: props.filterFns,
-  pageCount: props.pageCount,
-  rowCount: props.rowCount,
-  autoResetPageIndex: props.autoResetPageIndex,
-  enableSorting: props.enableSorting,
-  enableSortingRemoval: props.enableSortingRemoval,
-  enableMultiSort: props.enableMultiSort,
-  enableMultiRemove: props.enableMultiRemove,
-  maxMultiSortColCount: props.maxMultiSortColCount,
-  sortingFns: props.sortingFns,
-  isMultiSortEvent: props.isMultiSortEvent,
+  // getters, like `data` and `columns` above: the Vue adapter reads options
+  // through a lazy proxy, so a plain `x: props.x` is captured once at setup
+  // and never sees the prop change — a `rowCount` arriving after a fetch, or
+  // a `pageCount` recomputed for a new page size, left the table on a stale
+  // count
+  get enableMultiRowSelection() {
+    return props.enableMultiRowSelection
+  },
+  get enableSubRowSelection() {
+    return props.enableSubRowSelection
+  },
+  get autoResetAll() {
+    return props.autoResetAll
+  },
+  get enableRowSelection() {
+    return props.enableRowSelection
+  },
+  get enableColumnFilters() {
+    return props.enableColumnFilters
+  },
+  get manualPagination() {
+    return props.manualPagination
+  },
+  get manualSorting() {
+    return props.manualSorting
+  },
+  get manualFiltering() {
+    return props.manualFiltering
+  },
+  get globalFilterFn() {
+    return props.globalFilterFn
+  },
+  get filterFns() {
+    return props.filterFns
+  },
+  get pageCount() {
+    return props.pageCount
+  },
+  get rowCount() {
+    return props.rowCount
+  },
+  get autoResetPageIndex() {
+    return props.autoResetPageIndex
+  },
+  get enableSorting() {
+    return props.enableSorting
+  },
+  get enableSortingRemoval() {
+    return props.enableSortingRemoval
+  },
+  get enableMultiSort() {
+    return props.enableMultiSort
+  },
+  get enableMultiRemove() {
+    return props.enableMultiRemove
+  },
+  get maxMultiSortColCount() {
+    return props.maxMultiSortColCount
+  },
+  get sortingFns() {
+    return props.sortingFns
+  },
+  get isMultiSortEvent() {
+    return props.isMultiSortEvent
+  },
 
   getCoreRowModel: getCoreRowModel(),
   getSortedRowModel: getSortedRowModel(),


### PR DESCRIPTION
## What

Every plain option `NTable` hands to `useVueTable` — `rowCount`, `pageCount`, `manualPagination`, the `enable*` flags, `sortingFns`, `filterFns`, `isMultiSortEvent` — is now a getter over `props`, the way `data` and `columns` already were.

## Why

`@tanstack/vue-table` reads options through a lazy `mergeProxy`, so a plain `rowCount: props.rowCount` is evaluated once at setup and never again. A `rowCount` that arrives after a fetch, or a `pageCount` recomputed for a new page size, left the table on the stale value: `setPageIndex` clamped to it and the pagination bar reported it. The docs' server-side example only worked because SSR resolved its fetch before setup.

Verified on that example in the docs dev server: mutating the parent's `resource.count` to 5000 now moves `getRowCount()` and the bar to `5000` / `Page 1 of 500`, and back again when restored.

## Notes

- Found while writing the docs for #635; the docs PR is stacked on this branch and its server-side example relies on this.
- `pnpm typecheck` and lint pass. Merge with squash; close nothing — no ticket of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)