### PR TITLE
docs(Table): bring the table and pagination pages up to the new surface

### DIFF
--- a/docs/components/content/examples/vue/pagination/ExampleVuePaginationPageMeta.vue
+++ b/docs/components/content/examples/vue/pagination/ExampleVuePaginationPageMeta.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+const page = ref(1)
+const itemsPerPage = ref(10)
+</script>
+
+<template>
+  <div class="flex flex-col space-y-4">
+    <span>Page {{ page }}, {{ itemsPerPage }} per page</span>
+
+    <NPagination
+      v-model:page="page"
+      v-model:items-per-page="itemsPerPage"
+      :total="40"
+      :show-first="false"
+      :show-last="false"
+      show-info
+      show-rows-per-page
+      show-edges
+      :_pagination-info="{ format: 'range' }"
+      :_pagination-rows-per-page="{ label: 'Rows per page' }"
+    />
+  </div>
+</template>

--- a/docs/components/content/examples/vue/pagination/ExampleVuePaginationRegions.vue
+++ b/docs/components/content/examples/vue/pagination/ExampleVuePaginationRegions.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+const page = ref(3)
+</script>
+
+<template>
+  <NPagination
+    v-model:page="page"
+    :items-per-page="20"
+    :total="100"
+    :show-first="false"
+    :show-last="false"
+    show-edges
+  >
+    <template #start>
+      <NPaginationInfo v-slot="{ first, last, total }">
+        {{ first }}–{{ last }} of {{ total }} results
+      </NPaginationInfo>
+    </template>
+
+    <template #end>
+      <NButton
+        btn="outline-gray"
+        size="sm"
+        label="Export"
+        leading="i-lucide-download"
+      />
+    </template>
+  </NPagination>
+</template>

--- a/docs/components/content/examples/vue/table/ExampleVueTablePaginationCustom.vue
+++ b/docs/components/content/examples/vue/table/ExampleVueTablePaginationCustom.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import type { ColumnDef } from '@tanstack/vue-table'
+import type { Person } from './makeData'
+import makeData from './makeData'
+
+const data = ref(makeData(50))
+
+const columns: ColumnDef<Person>[] = [
+  {
+    header: 'First Name',
+    accessorKey: 'firstName',
+  },
+  {
+    header: 'Last Name',
+    accessorKey: 'lastName',
+  },
+  {
+    header: 'Age',
+    accessorKey: 'age',
+  },
+  {
+    header: 'Visits',
+    accessorKey: 'visits',
+  },
+  {
+    header: 'Status',
+    accessorKey: 'status',
+  },
+  {
+    header: 'Profile Progress',
+    accessorKey: 'progress',
+  },
+]
+
+const pagination = ref({
+  pageSize: 5,
+  pageIndex: 0,
+})
+</script>
+
+<template>
+  <NTable
+    v-model:pagination="pagination"
+    :columns
+    :data
+    enable-row-selection
+  >
+    <!-- the bar reads the table from context, so it needs no props -->
+    <template #pagination>
+      <NTablePagination
+        :_pagination-rows-per-page="{ pageSizes: [5, 10, 25], label: 'Per page' }"
+      >
+        <template #status="{ selected, filtered }">
+          {{ selected }} of {{ filtered }} selected
+        </template>
+      </NTablePagination>
+    </template>
+  </NTable>
+</template>

--- a/docs/components/content/examples/vue/table/ExampleVueTableServerSide.vue
+++ b/docs/components/content/examples/vue/table/ExampleVueTableServerSide.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ColumnDef, Table } from '@tanstack/vue-table'
+import type { ColumnDef } from '@tanstack/vue-table'
 
 interface Pokemon {
   name: string
@@ -14,11 +14,11 @@ interface ResourceMeta {
 }
 
 const pagination = ref({
-  pageSize: 5,
+  pageSize: 10,
   pageIndex: 0,
 })
 
-const endpoint = computed (() => {
+const endpoint = computed(() => {
   const { pageSize, pageIndex } = pagination.value
 
   return `https://pokeapi.co/api/v2/pokemon?limit=${pageSize}&offset=${pageSize * pageIndex}`
@@ -26,11 +26,9 @@ const endpoint = computed (() => {
 
 const { data: resource, refresh, status } = await useLazyFetch<ResourceMeta>(endpoint)
 
-const data = computed(() => {
-  return resource.value?.results ?? []
-})
+const data = computed(() => resource.value?.results ?? [])
 
-const columns = ref<ColumnDef<Pokemon>[]>([
+const columns: ColumnDef<Pokemon>[] = [
   {
     header: 'Name',
     accessorKey: 'name',
@@ -39,78 +37,29 @@ const columns = ref<ColumnDef<Pokemon>[]>([
     header: 'Url',
     accessorKey: 'url',
   },
-])
-
-const pageCount = computed(() => {
-  const { pageSize } = pagination.value
-
-  return Math.ceil((resource.value?.count || 0) / pageSize)
-})
-
-const table = useTemplateRef<Table<Pokemon>>('table')
+]
 </script>
 
 <template>
   <div class="flex flex-col space-y-4">
-    <!-- header -->
-    <div class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
-      <div class="flex items-center gap-x-2 sm:ml-auto">
-        <NButton
-          :loading="status === 'pending'"
-          @click="refresh()"
-        >
-          Reload
-        </NButton>
-      </div>
+    <div class="flex justify-end">
+      <NButton
+        :loading="status === 'pending'"
+        @click="refresh()"
+      >
+        Reload
+      </NButton>
     </div>
 
-    <!-- table -->
+    <!-- the table only ever holds one page: `row-count` gives the bar the full size -->
     <NTable
-      ref="table"
       v-model:pagination="pagination"
       manual-pagination
+      :row-count="resource?.count"
       :columns
-      :loading="status === 'pending'"
-      :page-count
       :data
+      :loading="status === 'pending'"
+      show-pagination
     />
-
-    <!-- footer -->
-    <div
-      class="flex items-center justify-end px-2"
-    >
-      <div class="flex items-center justify-between space-x-6 lg:space-x-8">
-        <div
-          class="hidden items-center justify-center text-sm font-medium sm:flex space-x-2"
-        >
-          <span class="text-nowrap">
-            Rows per page
-          </span>
-
-          <NSelect
-            :items="[5, 10, 20, 30, 40, 50]"
-            :_select-trigger="{
-              class: 'w-15',
-            }"
-            :model-value="table?.getState().pagination.pageSize"
-            @update:model-value="table?.setPageSize($event as unknown as number)"
-          />
-        </div>
-
-        <div
-          class="flex items-center justify-center text-sm font-medium"
-        >
-          Page {{ (table?.getState().pagination.pageIndex ?? 0) + 1 }} of  {{ pageCount }}
-        </div>
-
-        <NPagination
-          :page="(table?.getState().pagination.pageIndex ?? 0) + 1"
-          :total="pageCount * pagination.pageSize"
-          :show-list-item="false"
-          :items-per-page="table?.getState().pagination.pageSize ?? 5"
-          @update:page="table?.setPageIndex($event - 1)"
-        />
-      </div>
-    </div>
   </div>
 </template>

--- a/docs/components/content/examples/vue/table/ExampleVueTableSlots.vue
+++ b/docs/components/content/examples/vue/table/ExampleVueTableSlots.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ColumnDef, RowSelectionState, Table } from '@tanstack/vue-table'
+import type { ColumnDef, RowSelectionState } from '@tanstack/vue-table'
 import type { Person } from './makeData'
 import { NAvatar } from '#components'
 
@@ -67,8 +67,6 @@ const columns: ColumnDef<Person>[] = [
 
 const search = ref('')
 const select = ref<RowSelectionState>()
-
-const table = useTemplateRef<Table<Person>>('table')
 </script>
 
 <template>
@@ -105,13 +103,13 @@ const table = useTemplateRef<Table<Person>>('table')
 
     <!-- table -->
     <NTable
-      ref="table"
       v-model:row-selection="select"
       :columns
       :data
       :global-filter="search"
       enable-row-selection enable-column-filters enable-sorting
       row-id="username"
+      show-pagination
     >
       <!-- filters -->
       <template #status-filter="{ column }">
@@ -175,50 +173,5 @@ const table = useTemplateRef<Table<Person>>('table')
       </template>
       <!-- end cell -->
     </NTable>
-
-    <!-- footer -->
-    <div
-      class="flex items-center justify-between px-2"
-    >
-      <div
-        class="hidden text-sm text-muted-foreground sm:block"
-      >
-        {{ table?.getFilteredSelectedRowModel().rows.length.toLocaleString() }} of
-        {{ table?.getFilteredRowModel().rows.length.toLocaleString() }} row(s) selected.
-      </div>
-      <div class="flex items-center space-x-6 lg:space-x-8">
-        <div
-          class="hidden items-center justify-center text-sm font-medium sm:flex space-x-2"
-        >
-          <span class="text-nowrap">
-            Rows per page
-          </span>
-
-          <NSelect
-            :items="[10, 20, 30, 40, 50]"
-            :_select-trigger="{
-              class: 'w-15',
-            }"
-            :model-value="table?.getState().pagination.pageSize"
-            @update:model-value="table?.setPageSize($event as unknown as number)"
-          />
-        </div>
-
-        <div
-          class="flex items-center justify-center text-sm font-medium"
-        >
-          Page {{ (table?.getState().pagination.pageIndex ?? 0) + 1 }} of
-          {{ table?.getPageCount().toLocaleString() }}
-        </div>
-
-        <NPagination
-          :page="(table?.getState().pagination.pageIndex ?? 0) + 1"
-          :total="table?.getFilteredRowModel().rows.length"
-          :show-list-item="false"
-          :items-per-page="table?.getState().pagination.pageSize ?? 5"
-          @update:page="table?.setPageIndex($event - 1)"
-        />
-      </div>
-    </div>
   </div>
 </template>

--- a/docs/components/content/examples/vue/table/ExampleVueTableWidgets.vue
+++ b/docs/components/content/examples/vue/table/ExampleVueTableWidgets.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import type { ColumnDef } from '@tanstack/vue-table'
+import type { Person } from './makeData'
+import makeData from './makeData'
+
+const data = ref(makeData(5))
+const expanded = ref<Record<string, boolean>>({})
+
+const columns: ColumnDef<Person>[] = [
+  {
+    header: 'First Name',
+    accessorKey: 'firstName',
+    // per column, `meta` takes the same keys as the `_table*` props
+    meta: {
+      _tableColumnFilter: {
+        placeholder: 'Search first names…',
+        leading: 'i-lucide-search',
+      },
+    },
+  },
+  {
+    header: 'Last Name',
+    accessorKey: 'lastName',
+  },
+  {
+    header: 'Age',
+    accessorKey: 'age',
+    meta: {
+      _tableSortButton: { btn: 'soft-primary' },
+    },
+  },
+  {
+    header: 'Status',
+    accessorKey: 'status',
+    enableSorting: false,
+    enableColumnFilter: false,
+  },
+]
+</script>
+
+<template>
+  <NTable
+    v-model:expanded="expanded"
+    :columns
+    :data
+    enable-sorting
+    enable-column-filters
+    enable-row-selection
+    :_table-sort-button="{ btn: 'ghost-primary' }"
+    :_table-column-filter="{ size: 'sm' }"
+    :_table-selection-header="{ checkbox: 'lime' }"
+    :_table-selection-cell="{ checkbox: 'lime' }"
+    :_table-expand-button="{ btn: 'outline-gray', size: 'sm' }"
+    :una="{
+      tableSortAscIcon: 'i-lucide-arrow-up',
+      tableSortDescIcon: 'i-lucide-arrow-down',
+      tableSortNoneIcon: 'i-lucide-chevrons-up-down',
+    }"
+  >
+    <template #expanded="{ row }">
+      <p class="p-4 text-sm text-muted-foreground">
+        {{ row.original.email }}
+      </p>
+    </template>
+  </NTable>
+</template>

--- a/docs/content/3.components/pagination.md
+++ b/docs/content/3.components/pagination.md
@@ -100,7 +100,7 @@ By default, the size prop applies to height, width, padding, and font size. If y
 | Prop                    | Default         | Type                | Description                       |
 | ----------------------- | --------------- | ------------------- | --------------------------------- |
 | `pagination-selected`   | `solid-primary` | `{variant}-{color}` | The color of the selected page.   |
-| `pagination-unselected` | `solid-gray`    | `{variant}-{color}` | The color of the unselected page. |
+| `pagination-unselected` | `outline-gray`  | `{variant}-{color}` | The color of the unselected page. |
 | `pagination-ellipsis`   | `text-black`    | `{variant}-{color}` | The color of the ellipsis.        |
 
 :read-more{to="/components/button#color" title="Button variant and color section" target="_blank"}
@@ -129,15 +129,17 @@ By default, the size prop applies to height, width, padding, and font size. If y
 
 ### Sub Components
 
-| Prop                    | API reference                                                                               | Description                                          |
-| ----------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `_pagination-list-item` | [Reka Pagination ListItem API](https://www.reka-ui.com/docs/components/pagination#list)     | Customizes the pagination list item component.       |
-| `_pagination-prev`      | [Reka Pagination Prev API](https://www.reka-ui.com/docs/components/pagination#prev)         | Customizes the previous page navigation button.      |
-| `_pagination-next`      | [Reka Pagination Next API](https://www.reka-ui.com/docs/components/pagination#next)         | Customizes the next page navigation button.          |
-| `_pagination-first`     | [Reka Pagination First API](https://www.reka-ui.com/docs/components/pagination#first)       | Customizes the first page navigation button.         |
-| `_pagination-last`      | [Reka Pagination Last API](https://www.reka-ui.com/docs/components/pagination#last)         | Customizes the last page navigation button.          |
-| `_pagination-ellipsis`  | [Reka Pagination Ellipsis API](https://www.reka-ui.com/docs/components/pagination#ellipsis) | Customizes the ellipsis indicator in the pagination. |
-| `_pagination-list`      | [Reka Pagination List API](https://www.reka-ui.com/docs/components/pagination#list)         | Customizes the pagination list component.            |
+| Prop                        | API reference                                                                               | Description                                          |
+| --------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `_pagination-list-item`     | [Reka Pagination ListItem API](https://www.reka-ui.com/docs/components/pagination#list)     | Customizes the pagination list item component.       |
+| `_pagination-prev`          | [Reka Pagination Prev API](https://www.reka-ui.com/docs/components/pagination#prev)         | Customizes the previous page navigation button.      |
+| `_pagination-next`          | [Reka Pagination Next API](https://www.reka-ui.com/docs/components/pagination#next)         | Customizes the next page navigation button.          |
+| `_pagination-first`         | [Reka Pagination First API](https://www.reka-ui.com/docs/components/pagination#first)       | Customizes the first page navigation button.         |
+| `_pagination-last`          | [Reka Pagination Last API](https://www.reka-ui.com/docs/components/pagination#last)         | Customizes the last page navigation button.          |
+| `_pagination-ellipsis`      | [Reka Pagination Ellipsis API](https://www.reka-ui.com/docs/components/pagination#ellipsis) | Customizes the ellipsis indicator in the pagination. |
+| `_pagination-list`          | [Reka Pagination List API](https://www.reka-ui.com/docs/components/pagination#list)         | Customizes the pagination list component.            |
+| `_pagination-info`          | [Page meta](#page-meta)                                                                     | Customizes the page info text.                       |
+| `_pagination-rows-per-page` | [Page meta](#page-meta)                                                                     | Customizes the rows-per-page select.                 |
 
 :::CodeGroup
 ::div{label="Preview" preview}
@@ -176,6 +178,18 @@ exactly as it did before.
 ::
 :::
 
+The regions take anything. Here `start` holds `NPaginationInfo`, its scoped
+slot rewording the range, and `end` holds a button:
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVuePaginationRegions
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/pagination/ExampleVuePaginationRegions.vue
+::
+:::
+
 ## Page meta
 
 Two opt-in parts render into the `start` region. Both default to `false`, so
@@ -188,27 +202,45 @@ an existing `NPagination` renders exactly what it did before.
 | `_paginationInfo`        | `{}`    | `object`  | Props for the info part.             |
 | `_paginationRowsPerPage` | `{}`    | `object`  | Props for the rows-per-page control. |
 
-`NPaginationInfo` takes a `format` of `page` (default, "Page 1 of 5"), `range`
-("Showing 1–10 of 50") or `total` ("50 items"). `range` and `total` need
-`total`, which is optional on the root, so both fall back to the page form when
-it is absent. For anything else, its default slot exposes `page`, `pageCount`,
-`total`, `itemsPerPage`, `first` and `last` — which is also how you localise it,
-since the built-in strings are English.
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVuePaginationPageMeta
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/pagination/ExampleVuePaginationPageMeta.vue
+::
+:::
 
-`NPaginationRowsPerPage` wraps `NSelect` over a `pageSizes` list, defaulting to
-`[10, 20, 30, 40, 50]`, and writes back through `update:itemsPerPage`.
+### Info
 
-```vue
-<NPagination
-  v-model:page="page"
-  v-model:items-per-page="itemsPerPage"
-  :total="100"
-  show-info
-  show-rows-per-page
-  :_pagination-info="{ format: 'range' }"
-  :_pagination-rows-per-page="{ label: 'Rows per page' }"
-/>
-```
+`NPaginationInfo` renders where the reader is as text.
+
+| Prop                                         | Default | Type                       | Description                                                   |
+| -------------------------------------------- | ------- | -------------------------- | ------------------------------------------------------------- |
+| `format`                                     | `page`  | `page`, `range` or `total` | `Page 1 of 5`, `Showing 1–10 of 50` or `50 items`.            |
+| `page`, `pageCount`, `total`, `itemsPerPage` | -       | `number`                   | Standalone fallbacks; read from context inside `NPagination`. |
+
+`range` and `total` need `total`, which is optional on the root, so both fall
+back to the page form when it is absent. For any other wording — or another
+language, since the built-in strings are English — its default slot exposes
+`page`, `pageCount`, `total`, `itemsPerPage`, `first` and `last`. The page is
+clamped into `1…pageCount` before anything is rendered, so a page size that
+shrinks the page count never prints an impossible range.
+
+### Rows per page
+
+`NPaginationRowsPerPage` wraps `NSelect` over a list of page sizes.
+
+| Prop                   | Default                | Type       | Description                                                   |
+| ---------------------- | ---------------------- | ---------- | ------------------------------------------------------------- |
+| `pageSizes`            | `[10, 20, 30, 40, 50]` | `number[]` | The sizes to offer.                                           |
+| `label`                | -                      | `string`   | Caption rendered before the select. Also available as a slot. |
+| `itemsPerPage`         | -                      | `number`   | Standalone fallback; read from context inside `NPagination`.  |
+| `@update:itemsPerPage` | -                      | `number`   | Emitted with the chosen size.                                 |
+
+Every other `NSelect` prop passes through — `_selectTrigger`, `placeholder`,
+`disabled` and so on. Inside `NPagination` it writes back through
+`v-model:items-per-page`.
 
 ::alert{type="info"}
 `itemsPerPage` is a plain prop on the underlying primitive, so `:items-per-page`
@@ -219,7 +251,23 @@ for you.
 ::
 
 Both parts also work on their own, outside `NPagination`, by passing the values
-they would otherwise read from context.
+they would otherwise read from context:
+
+```vue
+<NPaginationInfo
+  format="range"
+  :page="2"
+  :page-count="5"
+  :items-per-page="10"
+  :total="42"
+/>
+
+<NPaginationRowsPerPage
+  label="Rows per page"
+  :items-per-page="size"
+  @update:items-per-page="n => size = n"
+/>
+```
 
 ## Presets
 
@@ -258,6 +306,14 @@ they would otherwise read from context.
 ::
 ::div{label="PaginationPrev.vue" icon="i-vscode-icons-file-type-vue"}
 @@@ ../packages/nuxt/src/runtime/components/elements/pagination/PaginationPrev.vue
+
+::
+::div{label="PaginationInfo.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/elements/pagination/PaginationInfo.vue
+
+::
+::div{label="PaginationRowsPerPage.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/elements/pagination/PaginationRowsPerPage.vue
 
 ::
 :::

--- a/docs/content/3.components/table.md
+++ b/docs/content/3.components/table.md
@@ -1,5 +1,8 @@
 ---
 description: 'A powerful, responsive table and datagrids built using Tanstack'
+navBadges:
+  - value: Breaking
+    type: warning
 badges:
   - value: Source
     icon: radix-icons:github-logo
@@ -9,6 +12,15 @@ badges:
     to: https://tanstack.com/table/latest/docs/introduction
     target: _blank
 ---
+
+::alert{type="warning"}
+**Breaking change.** The widgets `NTable` renders for you — the sort button, the
+column filter, the selection checkbox and the expand toggle — are now
+sub-components of their own, and the two columns it injects are named `select`
+and `expand` rather than `selection` and `expanded`. Slot names and column ids
+change with them, and `columns.meta` no longer reaches the DOM. See
+[Migrating](#migrating) below.
+::
 
 ## Examples
 
@@ -52,6 +64,11 @@ Row selection allows you to select rows in the table. This is useful when you wa
 ::alert{type="warning"}
 When using the `@row` event, you should stop propagation if you have interactive elements like buttons or links inside the row to prevent triggering the row click event.
 ::
+
+The checkboxes are `NTableSelectionHeader` and `NTableSelectionCell`, both
+`NCheckbox` underneath. Configure them through `_tableSelectionHeader` and
+`_tableSelectionCell`, or replace them with the `select-header` and
+`select-cell` slots — see [Widgets](#widgets).
 
 :::CodeGroup
 ::div{label="Preview"}
@@ -122,22 +139,16 @@ Loading allows you to show a loading progress indicator in the table. This is us
 shadcn's pagination bar below the table: the selection count (or row range) on
 the left, then rows per page, `Page X of Y` and the navigation on the right.
 Page numbers are off by default, as in shadcn; turn them on with
-`_tablePagination: { showListItem: true }`. Configure the bar through
-`_tablePagination`, which takes `NPagination`'s props, or replace it entirely
-with the `pagination` slot.
+`_tablePagination: { showListItem: true }`. Below the `lg` breakpoint the bar
+keeps only `Page X of Y` and the previous/next buttons.
 
 | Prop               | Default                        | Type                                    | Description                                                 |
 | ------------------ | ------------------------------ | --------------------------------------- | ----------------------------------------------------------- |
 | `pagination`       | `{pageIndex: 0, pageSize: 10}` | `{pageIndex: Number, pageSize: Number}` | Pagination state, can be binded with `v-model`.             |
 | `manualPagination` | `false`                        | `boolean`                               | Enable manual pagination, ideal for server-side pagination. |
+| `rowCount`         | -                              | `number`                                | The full row count, for manual pagination.                  |
 | `showPagination`   | `false`                        | `boolean`                               | Render the built-in pagination bar.                         |
-| `_tablePagination` | `{}`                           | `object`                                | Props for the bar's inner `NPagination`.                    |
-
-With `manualPagination`, pass `rowCount` so the bar knows the full size — the
-table only ever holds the current page. When row selection is on, the bar's
-start region shows the selection count instead of the row range. To compose the
-bar yourself outside the root, `NTablePagination` also takes the table instance
-directly as a `table` prop.
+| `_tablePagination` | `{}`                           | `object`                                | Props for the bar, `NTablePagination`.                      |
 
 :::CodeGroup
 ::div{label="Preview"}
@@ -152,6 +163,48 @@ directly as a `table` prop.
 
 ::
 :::
+
+The bar is `NTablePagination`. It takes every `NPagination` prop except the
+state ones — `page`, `itemsPerPage` and `total` come from the table — plus:
+
+| Prop              | Default | Type      | Description                                                                  |
+| ----------------- | ------- | --------- | ---------------------------------------------------------------------------- |
+| `showInfo`        | `true`  | `boolean` | Render the status text on the left.                                          |
+| `showRowsPerPage` | `true`  | `boolean` | Render the rows-per-page select.                                             |
+| `table`           | -       | `Table`   | The table instance, when used outside `NTable`; read from context otherwise. |
+
+Pass them through `_tablePagination` for prop-only changes. For anything more —
+the status text, say, whose default is English — take over the `pagination`
+slot and render `NTablePagination` yourself. It reads the table from context, so
+it needs no props, and its `status` slot exposes `selected`, `filtered`,
+`total`, `first` and `last`. Providing the slot renders the bar on its own;
+`show-pagination` is only needed for the default one.
+
+:::CodeGroup
+::div{label="Preview"}
+:ExampleVueTablePaginationCustom
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/table/ExampleVueTablePaginationCustom.vue
+
+::
+::div{label="Data"}
+@@@ ./components/content/examples/vue/table/makeData.ts [makeData.ts]
+
+::
+:::
+
+With `manualPagination`, pass `rowCount` so the bar knows the full size — the
+table only ever holds the current page; see [Server-side](#server-side). When
+row selection is on, the status shows the selection count instead of the row
+range. To compose the bar outside the root, `NTablePagination` also takes the
+table instance directly:
+
+```vue
+<NTable ref="table" :columns :data />
+
+<NTablePagination v-if="table" :table />
+```
 
 :read-more{to="pagination" title="Pagination Component"}
 
@@ -168,6 +221,13 @@ Sorting allows you to sort columns in ascending or descending order. This is use
 | `enableSorting`        | -       | `boolean` | Enable all column sorting                            |
 | `column.enableSorting` | -       | `boolean` | Enable specific column sorting                       |
 | `enableSortingRemoval` | `true`  | `boolean` | Enables the ability to remove sorting for the table. |
+
+Sortable headers render `NTableSortButton`, a `NButton` whose trailing icon
+follows the column's sort state. Configure it through `_tableSortButton` (any
+`NButton` prop), re-point the icons with the `table-sort-asc-icon`,
+`table-sort-desc-icon` and `table-sort-none-icon` preset aliases or the matching
+`una` keys, and replace its content with the `{column}-header` slot. Sortable
+headers also carry `aria-sort`.
 
 :::CodeGroup
 ::div{label="Preview"}
@@ -241,8 +301,13 @@ Column filtering allows you to filter columns based on the value entered in the 
 | Prop                        | Default | Type      | Description                                        |
 | --------------------------- | ------- | --------- | -------------------------------------------------- |
 | `columnFilters`             | -       | `array`   | Column filter state, can be binded with `v-model`. |
-| `enableColumnFilter`        | -       | `boolean` | Enable all column filtering                        |
+| `enableColumnFilters`       | -       | `boolean` | Enable all column filtering                        |
 | `column.enableColumnFilter` | -       | `boolean` | Enable specific column filtering                   |
+
+Each filter is `NTableColumnFilter`, a `NInput` bound to the column's filter
+value with the header text as its placeholder. Configure it through
+`_tableColumnFilter` (any `NInput` prop), or replace it per column with the
+`{column}-filter` slot.
 
 :::CodeGroup
 ::div{label="Preview"}
@@ -312,9 +377,16 @@ Column pinning allows you to pin columns to the `left` or `right` of the table. 
 
 Expanding allows you to expand rows to show additional information. This is useful when you want to show additional information about a row.
 
-| Prop       | Default | Type    | Description                                   |
-| ---------- | ------- | ------- | --------------------------------------------- |
-| `expanded` | -       | `array` | Expanded state, can be binded with `v-model`. |
+| Prop       | Default | Type           | Description                                    |
+| ---------- | ------- | -------------- | ---------------------------------------------- |
+| `expanded` | -       | `object`       | Expanded state, can be binded with `v-model`.  |
+| `@expand`  | -       | `event`, `row` | Emitted when a row's expand toggle is clicked. |
+
+The toggle is `NTableExpandButton`, an icon-only `NButton` that turns its
+chevron while the row is open. Configure it through `_tableExpandButton`,
+re-point the icon with the `table-expand-icon` alias, or replace it with the
+`expand-cell` slot. `expanded` renders the row's content; `expand-cell` renders
+the toggle.
 
 :::CodeGroup
 ::div{label="Preview"}
@@ -361,7 +433,10 @@ Grouping allows you to group rows based on a column value. This is useful when y
 
 ### Server-side
 
-Allows you to fetch data from the server. This is useful when you want to fetch data from the server.
+Allows you to fetch data from the server. Set `manualPagination` so the table
+stops slicing the rows itself, and pass `rowCount` from the response so the
+pagination bar knows the full size — the table only ever holds the current
+page.
 
 :::CodeGroup
 ::div{label="Preview"}
@@ -382,7 +457,7 @@ Allows you to fetch data from the server. This is useful when you want to fetch 
 
 ## Customization
 
-Configure the progress using the `una` prop and utility classes.
+Configure the table using the `una` prop and utility classes.
 
 | Prop                    | Default | Type     | Description                                    |
 | ----------------------- | ------- | -------- | ---------------------------------------------- |
@@ -394,12 +469,6 @@ Configure the progress using the `una` prop and utility classes.
 | `_tableSelectionCell`   | `{}`    | `object` | Props for the per-row selection checkbox.      |
 | `_tableExpandButton`    | `{}`    | `object` | Props for the row expand toggle.               |
 | `_tablePagination`      | `{}`    | `object` | Props for the built-in pagination bar.         |
-
-Each of the five widgets `NTable` renders on your behalf is a component in its
-own right — `NTableSortButton`, `NTableColumnFilter`, `NTableSelectionHeader`,
-`NTableSelectionCell` and `NTableExpandButton` — so it accepts the full prop
-surface of what it wraps, and can be styled through its own `una` keys or
-swapped out entirely through the slots above.
 
 Set them for the whole table with the `_table*` props, or per column through
 `columns.meta`, which accepts the same keys:
@@ -417,8 +486,8 @@ const columns = [
 ]
 ```
 
-Only `una` and the five `_table*` keys are read from `columns.meta`; anything
-else you store there stays out of the DOM.
+Only `una` and the `_table*` keys are read from `columns.meta`; anything else
+you store there stays out of the DOM.
 
 :read-more{to="#props" title="Component Props API"}
 
@@ -431,6 +500,44 @@ else you store there stays out of the DOM.
 ::
 ::div{label="Code"}
 @@@ ./components/content/examples/vue/table/ExampleVueTableCustomization.vue
+
+::
+::div{label="Data"}
+@@@ ./components/content/examples/vue/table/makeData.ts [makeData.ts]
+
+::
+:::
+
+### Widgets
+
+Every widget `NTable` renders on your behalf is a component in its own right,
+so it takes the full prop surface of what it wraps, has `una` keys of its own,
+and can be swapped out through a slot:
+
+| Component               | Wraps         | Props                   | Slot              | Icon aliases                                                          |
+| ----------------------- | ------------- | ----------------------- | ----------------- | --------------------------------------------------------------------- |
+| `NTableSortButton`      | `NButton`     | `_tableSortButton`      | `{column}-header` | `table-sort-asc-icon`, `table-sort-desc-icon`, `table-sort-none-icon` |
+| `NTableColumnFilter`    | `NInput`      | `_tableColumnFilter`    | `{column}-filter` | -                                                                     |
+| `NTableSelectionHeader` | `NCheckbox`   | `_tableSelectionHeader` | `select-header`   | -                                                                     |
+| `NTableSelectionCell`   | `NCheckbox`   | `_tableSelectionCell`   | `select-cell`     | -                                                                     |
+| `NTableExpandButton`    | `NButton`     | `_tableExpandButton`    | `expand-cell`     | `table-expand-icon`                                                   |
+| `NTablePagination`      | `NPagination` | `_tablePagination`      | `pagination`      | -                                                                     |
+
+Their `una` keys — `tableSortButton`, `tableSortIconBase`, `tableSortAscIcon`,
+`tableSelection`, `tableExpandButton`, `tablePagination` and the rest — are
+listed under [Props](#props); the `*Icon` keys take an icon name, the others
+take classes. The icon aliases are preset shortcuts, so they can also be
+re-pointed for the whole app from your UnoCSS config. One thing to know: the
+sort button's `font-normal` is marked important in the `table-sort-button`
+shortcut, so override its weight with `font-medium!`.
+
+:::CodeGroup
+::div{label="Preview"}
+:ExampleVueTableWidgets
+
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/table/ExampleVueTableWidgets.vue
 
 ::
 ::div{label="Data"}
@@ -484,6 +591,40 @@ content) are different slots.
 ::
 :::
 
+## Migrating
+
+The widgets `NTable` injected into its columns were built inline, with literal
+props and no way to adjust them. They are now sub-components, which moved a
+handful of names and defaults:
+
+```diff
+- <template #selection-header>…</template>
+- <template #selection-cell>…</template>
+- <template #expanded-cell>…</template>
++ <template #select-header>…</template>
++ <template #select-cell>…</template>
++ <template #expand-cell>…</template>
+
+- :column-pinning="{ left: ['selection', 'firstName'] }"
++ :column-pinning="{ left: ['select', 'firstName'] }"
+```
+
+| Before                                                                   | After                                                                                                                                                                   |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Injected columns with the ids `selection` and `expanded`                 | `select` and `expand`, as in shadcn. Rename them wherever a column id appears — `columnOrder`, `columnPinning`, `columnVisibility`.                                     |
+| `#selection-header`, `#selection-cell`, `#expanded-cell`                 | `#select-header`, `#select-cell`, `#expand-cell`. `#expanded`, the row content, is unchanged.                                                                           |
+| A column of your own with the id `select` or `expand`                    | Rename it. TanStack keys columns by id and silently drops one of the two; `NTable` now warns in dev.                                                                    |
+| Any key on `columns.meta` landed on `<th>` and `<td>` as an attribute    | Only `una` and the `_table*` keys are read. Set attributes through `meta._tableHead` and `meta._tableCell`.                                                             |
+| Sort button, filter input, checkboxes and expand toggle hardcoded        | `NTableSortButton`, `NTableColumnFilter`, `NTableSelectionHeader`, `NTableSelectionCell`, `NTableExpandButton` — configured through the `_table*` props and `una` keys. |
+| Sort and expand icons hardcoded                                          | The `table-sort-asc-icon`, `table-sort-desc-icon`, `table-sort-none-icon` and `table-expand-icon` preset aliases, or the matching `una` keys.                           |
+| The selection checkboxes and the expand toggle had no accessible name    | `aria-label` on all three, `aria-sort` on sortable headers, `data-expanded` on the toggle.                                                                              |
+| `table-default-variant`, `table-loading-icon`, `table-loading-icon-name` | Removed — none of them rendered anything.                                                                                                                               |
+| `NTableLoading` ignored its `colspan`                                    | Honoured; `NTable` passes its leaf-column count.                                                                                                                        |
+| `NTable` rendered a single root element                                  | It renders a fragment — the root plus, with `show-pagination`, the bar. Attributes still land on `<table>`; if you relied on `$el`, wrap it yourself.                   |
+
+The pagination bar — `showPagination`, `_tablePagination`, the `pagination`
+slot — is additive; a table without them renders as before.
+
 ## Presets
 
 @@@ ../packages/preset/src/_shortcuts/table.ts [shortcuts/table.ts]
@@ -497,10 +638,6 @@ content) are different slots.
 :::CodeGroup
 ::div{label="Table.vue" icon="i-vscode-icons-file-type-vue"}
 @@@ ../packages/nuxt/src/runtime/components/data/table/Table.vue
-
-::
-::div{label="TableRoot.vue" icon="i-vscode-icons-file-type-vue"}
-@@@ ../packages/nuxt/src/runtime/components/data/table/TableRoot.vue
 
 ::
 ::div{label="TableHeader.vue" icon="i-vscode-icons-file-type-vue"}
@@ -537,6 +674,30 @@ content) are different slots.
 ::
 ::div{label="TableCaption.vue" icon="i-vscode-icons-file-type-vue"}
 @@@ ../packages/nuxt/src/runtime/components/data/table/TableCaption.vue
+
+::
+::div{label="TableSortButton.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/data/table/TableSortButton.vue
+
+::
+::div{label="TableColumnFilter.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/data/table/TableColumnFilter.vue
+
+::
+::div{label="TableSelectionHeader.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/data/table/TableSelectionHeader.vue
+
+::
+::div{label="TableSelectionCell.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/data/table/TableSelectionCell.vue
+
+::
+::div{label="TableExpandButton.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/data/table/TableExpandButton.vue
+
+::
+::div{label="TablePagination.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/data/table/TablePagination.vue
 
 ::
 :::

--- a/packages/nuxt/src/runtime/components/data/table/Table.vue
+++ b/packages/nuxt/src/runtime/components/data/table/Table.vue
@@ -148,26 +148,71 @@ const table = useVueTable({
     get grouping() { return grouping.value },
   },
 
-  enableMultiRowSelection: props.enableMultiRowSelection,
-  enableSubRowSelection: props.enableSubRowSelection,
-  autoResetAll: props.autoResetAll,
-  enableRowSelection: props.enableRowSelection,
-  enableColumnFilters: props.enableColumnFilters,
-  manualPagination: props.manualPagination,
-  manualSorting: props.manualSorting,
-  manualFiltering: props.manualFiltering,
-  globalFilterFn: props.globalFilterFn,
-  filterFns: props.filterFns,
-  pageCount: props.pageCount,
-  rowCount: props.rowCount,
-  autoResetPageIndex: props.autoResetPageIndex,
-  enableSorting: props.enableSorting,
-  enableSortingRemoval: props.enableSortingRemoval,
-  enableMultiSort: props.enableMultiSort,
-  enableMultiRemove: props.enableMultiRemove,
-  maxMultiSortColCount: props.maxMultiSortColCount,
-  sortingFns: props.sortingFns,
-  isMultiSortEvent: props.isMultiSortEvent,
+  // getters, like `data` and `columns` above: the Vue adapter reads options
+  // through a lazy proxy, so a plain `x: props.x` is captured once at setup
+  // and never sees the prop change — a `rowCount` arriving after a fetch, or
+  // a `pageCount` recomputed for a new page size, left the table on a stale
+  // count
+  get enableMultiRowSelection() {
+    return props.enableMultiRowSelection
+  },
+  get enableSubRowSelection() {
+    return props.enableSubRowSelection
+  },
+  get autoResetAll() {
+    return props.autoResetAll
+  },
+  get enableRowSelection() {
+    return props.enableRowSelection
+  },
+  get enableColumnFilters() {
+    return props.enableColumnFilters
+  },
+  get manualPagination() {
+    return props.manualPagination
+  },
+  get manualSorting() {
+    return props.manualSorting
+  },
+  get manualFiltering() {
+    return props.manualFiltering
+  },
+  get globalFilterFn() {
+    return props.globalFilterFn
+  },
+  get filterFns() {
+    return props.filterFns
+  },
+  get pageCount() {
+    return props.pageCount
+  },
+  get rowCount() {
+    return props.rowCount
+  },
+  get autoResetPageIndex() {
+    return props.autoResetPageIndex
+  },
+  get enableSorting() {
+    return props.enableSorting
+  },
+  get enableSortingRemoval() {
+    return props.enableSortingRemoval
+  },
+  get enableMultiSort() {
+    return props.enableMultiSort
+  },
+  get enableMultiRemove() {
+    return props.enableMultiRemove
+  },
+  get maxMultiSortColCount() {
+    return props.maxMultiSortColCount
+  },
+  get sortingFns() {
+    return props.sortingFns
+  },
+  get isMultiSortEvent() {
+    return props.isMultiSortEvent
+  },
 
   getCoreRowModel: getCoreRowModel(),
   getSortedRowModel: getSortedRowModel(),


### PR DESCRIPTION
Ticket #635 — the last on the [table & pagination map](https://github.com/una-ui/una-ui/issues/627). Close by hand after merge.

## What

**`table.md`**
- A `Breaking` nav badge, a warning at the top and a new **Migrating** section: a diff of the renamed slots and ids, and a before/after table covering every default that shifted since `v1.0.0-alpha.26` — the `select`/`expand` column ids and slots, the narrowed `columns.meta`, the removed preset keys, the sub-components and icon aliases, the accessible names, the honoured `colspan`, and the fragment root.
- Pagination: `rowCount` in the prop table, `NTablePagination`'s own props (`showInfo`, `showRowsPerPage`, `table`), the `#pagination` slot and its `#status` path, standalone usage, and a second example customizing the bar.
- Row Selection, Sorting, Column Filtering, Expanding and Server-side each name the part they render and how to configure or replace it; `@expand` is documented; `enableColumnFilter` corrected to `enableColumnFilters`.
- Customization: a **Widgets** subsection with a component / wraps / props / slot / icon-alias table and an example configuring all five widgets through `_table*` props, `columns.meta` and the `una` icon keys.
- Components: the dead `TableRoot.vue` entry dropped (the file went in ac9c71b3), the six new SFCs added.

**`pagination.md`**
- `_pagination-info` and `_pagination-rows-per-page` in Sub Components; Page meta split into **Info** and **Rows per page** with prop tables, a live example and the standalone snippet; a regions example under Slots; `PaginationInfo.vue` and `PaginationRowsPerPage.vue` in Components; the `pagination-unselected` default corrected to `outline-gray`.

**Examples**
- New: `ExampleVueTableWidgets`, `ExampleVueTablePaginationCustom`, `ExampleVuePaginationPageMeta`, `ExampleVuePaginationRegions`.
- `ExampleVueTableServerSide` and `ExampleVueTableSlots` drop their hand-rolled footers for `show-pagination`, the former with `row-count` from the response.

## Verified

On the docs dev server at a 1280px viewport (a 619px content column): every new example renders; each configured override lands in the DOM (`btn="ghost-primary"` and the per-column `soft-primary`, `checkbox="lime"` on both checkboxes, `size="sm"` filter inputs at 32px against the default 36px, the custom sort icons, `aria-sort` and the `aria-label`s); the four table bars sit on one row; and the two pagination-page examples fit their column (540px and 555px of 619px) after trimming first/last. Lint and `vue-tsc` pass.

## Stacked on #649

The server-side example relies on `row-count` being read reactively, which #649 fixes; this PR is based on that branch so its diff is docs-only. Merge #649 first; I will retarget this one to `v1.0.0` for the squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)