### PR TITLE
fix(Table): emit row data from @expand, not the TanStack wrapper

### DIFF
--- a/packages/nuxt/src/runtime/components/data/table/TableExpandButton.vue
+++ b/packages/nuxt/src/runtime/components/data/table/TableExpandButton.vue
@@ -28,7 +28,7 @@ const isExpanded = computed(() => props.row.getIsExpanded())
 
 function onClick() {
   props.row.toggleExpanded()
-  emit('change', props.row)
+  emit('change', props.row.original)
 }
 </script>
 


### PR DESCRIPTION
Follow-up to the review on #650.

`NTable`'s `@expand` handed listeners the TanStack `Row<TData>` wrapper instead of the row data, disagreeing with its own type declaration and with both sibling events.

`TableExpandButton` was the only one of the three emitting widgets that did not unwrap:

| Widget | Emitted | `NTable` event | Declared |
| --- | --- | --- | --- |
| `TableSelectionHeader` | `rows.map(row => row.original)` | `@select-all` | `selectAll: [rows: TData[]]` |
| `TableSelectionCell` | `props.row.original` | `@select` | `select: [row: TData]` |
| `TableExpandButton` | `props.row` | `@expand` | `expand: [row: TData]` |

`Table.vue` forwards it untransformed (`@change="emit('expand', $event)"`), so the wrapper reached userland while the declaration promised `TData`. The docs merged in #650 document it as `event`, `row` — matching the declaration, not the runtime.

The type and the docs were already correct, so this fixes the emit rather than widening the contract.

### Behavior change

`@expand` listeners, and anyone using `NTableExpandButton`'s own `change`, now receive the row data. Handlers reaching for `.original` on the payload should drop it. Nothing in `docs/` or `playground/` consumes `@expand`, so no examples needed updating.

This predates #650 and #649 — it arrived with the widget extraction in #638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)