### PR TITLE
chore: keep vitest out of Claude Code worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs-beta
 
 # Claude Code local harness config (regenerated on demand)
 .claude/launch.json
+.claude/worktrees/

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { configDefaults, defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // Claude Code keeps other sessions' worktrees under `.claude/worktrees`,
+    // inside the repo, so vitest's default glob found every test file in them
+    // and ran each against a `tsconfig` whose `.nuxt/` extends target had
+    // never been generated there
+    exclude: [...configDefaults.exclude, '**/.claude/**'],
+  },
+})


### PR DESCRIPTION
## Why

`pnpm test` (and so `pnpm release:v1`) fails locally with six failing test *files* while all 108 tests pass. Every failure is a copy of `test/index.test.ts` or `useSidebar.test.ts` under `.claude/worktrees/<session>/…`: Claude Code keeps other sessions' worktrees there, inside the repo, and with no root vitest config the default glob walks into them. Those copies then fail on `failed to resolve "extends":"./.nuxt/tsconfig.json"`, because `nuxt prepare` never ran in the worktree.

## What

- `vitest.config.ts` at the root, extending the default excludes with `**/.claude/**`.
- `.claude/worktrees/` added to `.gitignore` (it was only invisible because of the nested `.git` files).

After: 9 files, 108 tests, 0 failures. CI is unaffected either way — no worktrees exist there — so this is a local-only fix. Worth cherry-picking to `main` too, since the same `pnpm test` runs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)